### PR TITLE
Feature/#140

### DIFF
--- a/src/main/java/com/mozi/moziserver/common/Constant.java
+++ b/src/main/java/com/mozi/moziserver/common/Constant.java
@@ -99,6 +99,8 @@ public interface Constant {
 
     int totalImagesPerIsland = 11;
 
+    int TUTORIAL_ANIMAL_ITEM_POINT = 5;
+
     List<String> RANDOM_ANIMAL_MENTIONS = Arrays.asList(
             "매주 일요일 위시리스트를 받을 수 있어!",
             "위시리스트 2개를 모으면 내가 이사갈 수 있어!",

--- a/src/main/java/com/mozi/moziserver/common/Constant.java
+++ b/src/main/java/com/mozi/moziserver/common/Constant.java
@@ -85,7 +85,7 @@ public interface Constant {
             Arrays.asList("devwon.com")
     );
 
-    List<String> IMAGE_MIME_TYPE_LIST = List.of("image/png", "image/jpeg");
+    List<String> IMAGE_MIME_TYPE_LIST = List.of("image/png", "image/jpeg", "image/heic");
 
     int challengeExtraPoints = 5;
 
@@ -98,4 +98,11 @@ public interface Constant {
     int lastTurnOfAnimalItem = 2;
 
     int totalImagesPerIsland = 11;
+
+    List<String> RANDOM_ANIMAL_MENTIONS = Arrays.asList(
+            "매주 일요일 위시리스트를 받을 수 있어!",
+            "위시리스트 2개를 모으면 내가 이사갈 수 있어!",
+            "위시리스트는 일주일에 하나씩 받을 수 있어!",
+            "이주 동물마다 필요한 위시 포인트가 달라!"
+    );
 }

--- a/src/main/java/com/mozi/moziserver/common/JpaUtil.java
+++ b/src/main/java/com/mozi/moziserver/common/JpaUtil.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 public class JpaUtil {
-    private final static Integer SQL_ERROR_UNIQUE_KEY_DUPLICATE = 1062;
+    private final static Integer SQL_ERROR_UNIQUE_KEY_DUPLICATE = 1062; // MySQL 한정 에러 코드
 
     public static boolean isDuplicateKeyException(DataIntegrityViolationException e) {
         if (e.getCause() == null || !(e.getCause() instanceof ConstraintViolationException)) {

--- a/src/main/java/com/mozi/moziserver/common/JsonUtil.java
+++ b/src/main/java/com/mozi/moziserver/common/JsonUtil.java
@@ -1,0 +1,12 @@
+package com.mozi.moziserver.common;
+
+import com.google.gson.Gson;
+
+public class JsonUtil {
+
+    private static final Gson gson = new Gson();
+
+    public static String toJson(Object src) {
+        return gson.toJson(src);
+    }
+}

--- a/src/main/java/com/mozi/moziserver/model/AnimalMentionFcmMessage.java
+++ b/src/main/java/com/mozi/moziserver/model/AnimalMentionFcmMessage.java
@@ -1,0 +1,46 @@
+package com.mozi.moziserver.model;
+
+import com.google.firebase.messaging.Message;
+import com.mozi.moziserver.common.JsonUtil;
+import com.mozi.moziserver.model.mappedenum.FcmMessageType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class AnimalMentionFcmMessage extends FcmMessage {
+
+    private final Long islandSeq;
+    private final Long animalSeq;
+    private final String animalImgUrl;
+    private final List<String> mentionList;
+
+    @Builder
+    public AnimalMentionFcmMessage(@NonNull FcmMessageType fcmMessageType, @NonNull LocalDateTime expirationDateTime, @NonNull Long islandSeq, @NonNull Long animalSeq, @NonNull String animalImgUrl, @NonNull List<String> mentionList) {
+
+        super(fcmMessageType, expirationDateTime);
+        this.islandSeq = islandSeq;
+        this.animalSeq = animalSeq;
+        this.animalImgUrl = animalImgUrl;
+        this.mentionList = mentionList;
+    }
+
+    @Override
+    public Message getMessage(String token) {
+
+        return Message.builder()
+                .putData("type", getFcmMessageType().toString())
+                .putData("isSilent", "" + getFcmMessageType().isSilent())
+                .putData("sendAt", String.valueOf(getSendAt()))
+                .putData("expirationDateTime", String.valueOf(getExpirationDateTime()))
+                .putData("islandSeq", String.valueOf(islandSeq))
+                .putData("animalSeq", String.valueOf(islandSeq))
+                .putData("animalImgUrl", animalImgUrl)
+                .putData("mentions", JsonUtil.toJson(mentionList))
+                .setToken(token)
+                .build();
+    }
+}

--- a/src/main/java/com/mozi/moziserver/model/AnimalMentionFcmMessage.java
+++ b/src/main/java/com/mozi/moziserver/model/AnimalMentionFcmMessage.java
@@ -14,16 +14,14 @@ import java.util.List;
 public class AnimalMentionFcmMessage extends FcmMessage {
 
     private final Long islandSeq;
-    private final Long animalSeq;
     private final String animalImgUrl;
     private final List<String> mentionList;
 
     @Builder
-    public AnimalMentionFcmMessage(@NonNull FcmMessageType fcmMessageType, @NonNull LocalDateTime expirationDateTime, @NonNull Long islandSeq, @NonNull Long animalSeq, @NonNull String animalImgUrl, @NonNull List<String> mentionList) {
+    public AnimalMentionFcmMessage(@NonNull FcmMessageType fcmMessageType, @NonNull LocalDateTime expirationDateTime, @NonNull Long islandSeq, @NonNull String animalImgUrl, @NonNull List<String> mentionList) {
 
         super(fcmMessageType, expirationDateTime);
         this.islandSeq = islandSeq;
-        this.animalSeq = animalSeq;
         this.animalImgUrl = animalImgUrl;
         this.mentionList = mentionList;
     }
@@ -37,7 +35,6 @@ public class AnimalMentionFcmMessage extends FcmMessage {
                 .putData("sendAt", String.valueOf(getSendAt()))
                 .putData("expirationDateTime", String.valueOf(getExpirationDateTime()))
                 .putData("islandSeq", String.valueOf(islandSeq))
-                .putData("animalSeq", String.valueOf(islandSeq))
                 .putData("animalImgUrl", animalImgUrl)
                 .putData("mentions", JsonUtil.toJson(mentionList))
                 .setToken(token)

--- a/src/main/java/com/mozi/moziserver/model/FcmMessage.java
+++ b/src/main/java/com/mozi/moziserver/model/FcmMessage.java
@@ -1,4 +1,38 @@
 package com.mozi.moziserver.model;
 
+import com.google.firebase.messaging.Message;
+import com.mozi.moziserver.model.mappedenum.FcmMessageType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class FcmMessage {
+
+    private final FcmMessageType fcmMessageType;
+    private final LocalDateTime sendAt;
+    private final LocalDateTime expirationDateTime;
+
+    protected FcmMessage(FcmMessageType fcmMessageType, LocalDateTime expirationDateTime) {
+
+        this.fcmMessageType = fcmMessageType;
+        this.sendAt = LocalDateTime.now();
+        this.expirationDateTime = expirationDateTime;
+    }
+
+    public Message getMessage(String token) {
+
+        return Message.builder()
+                .putData("type", getFcmMessageType().toString())
+                .putData("isSilent", "" + getFcmMessageType().isSilent())
+                .putData("sendAt", String.valueOf(getSendAt()))
+                .putData("expirationDateTime", String.valueOf(getExpirationDateTime()))
+                .setToken(token)
+                .build();
+    }
+
+    // TODO 이후, 나올 수 있는 메서드 예시 (FirebaseMessaging.getInstance()의 메서드 형태에 따라..)
+    // public Message getTopicMessage()
+    // public Multiple MulticastMessage getMulticastMessage
+    // 등..
 }

--- a/src/main/java/com/mozi/moziserver/model/entity/AnimalMention.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/AnimalMention.java
@@ -14,7 +14,9 @@ public class AnimalMention extends AbstractTimeEntity {
 
     private Integer itemTurn;
 
-    private Integer point;
+    private Integer startPoint;
+
+    private Integer rangePoint;
 
     private String content;
 

--- a/src/main/java/com/mozi/moziserver/model/entity/AnimalMention.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/AnimalMention.java
@@ -1,0 +1,24 @@
+package com.mozi.moziserver.model.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity(name = "animal_mention")
+public class AnimalMention extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    private Integer itemTurn;
+
+    private Integer point;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "animal_seq")
+    private Animal animal;
+}

--- a/src/main/java/com/mozi/moziserver/model/mappedenum/FcmMessageType.java
+++ b/src/main/java/com/mozi/moziserver/model/mappedenum/FcmMessageType.java
@@ -10,7 +10,8 @@ public enum FcmMessageType {
     END_USER_CHALLENGE_MESSAGE(true),
     POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM(true),
     POSTBOX_MESSAGE_ANIMAL_NEW_ARRIVED(true),
-    MOVING_DAY_OF_NEW_ANIMAL(true);
+    MOVING_DAY_OF_NEW_ANIMAL(true),
+    ANIMAL_MENTION(true);
 
     private final boolean isSilent;
 }

--- a/src/main/java/com/mozi/moziserver/repository/AnimalMentionRepository.java
+++ b/src/main/java/com/mozi/moziserver/repository/AnimalMentionRepository.java
@@ -6,15 +6,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.*;
 
 @Repository
 public interface AnimalMentionRepository extends JpaRepository<AnimalMention, Long> {
 
-    @Query(name = "SELECT FROM animal_mention WHERE animal_seq = :animalSeq AND item_turn = :itemTurn AND point >= :point ORDER BY point LIMIT 1")
-    Optional<AnimalMention> findByAnimalSeqAndItemTurnAndPoint(
+    @Query("SELECT a FROM animal_mention a WHERE a.animal.seq = :animalSeq AND a.itemTurn = :itemTurn AND a.startPoint <= :userWeekPoint AND :userWeekPoint < (a.startPoint + a.rangePoint)")
+    List<AnimalMention> findByAnimalSeqAndItemTurnAndUserWeekPoint(
             @Param("animalSeq") Long animalSeq,
             @Param("itemTurn") Integer itemTurn,
-            @Param("point") Integer point
+            @Param("userWeekPoint") Integer userWeekPoint
     );
 }

--- a/src/main/java/com/mozi/moziserver/repository/AnimalMentionRepository.java
+++ b/src/main/java/com/mozi/moziserver/repository/AnimalMentionRepository.java
@@ -1,0 +1,20 @@
+package com.mozi.moziserver.repository;
+
+import com.mozi.moziserver.model.entity.AnimalMention;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AnimalMentionRepository extends JpaRepository<AnimalMention, Long> {
+
+    @Query(name = "SELECT FROM animal_mention WHERE animal_seq = :animalSeq AND item_turn = :itemTurn AND point >= :point ORDER BY point LIMIT 1")
+    Optional<AnimalMention> findByAnimalSeqAndItemTurnAndPoint(
+            @Param("animalSeq") Long animalSeq,
+            @Param("itemTurn") Integer itemTurn,
+            @Param("point") Integer point
+    );
+}

--- a/src/main/java/com/mozi/moziserver/service/AnimalService.java
+++ b/src/main/java/com/mozi/moziserver/service/AnimalService.java
@@ -1,14 +1,20 @@
 package com.mozi.moziserver.service;
 
+import com.mozi.moziserver.common.Constant;
 import com.mozi.moziserver.httpException.ResponseError;
 import com.mozi.moziserver.model.entity.Animal;
 import com.mozi.moziserver.model.entity.AnimalItem;
+import com.mozi.moziserver.model.entity.AnimalMention;
 import com.mozi.moziserver.repository.AnimalItemRepository;
+import com.mozi.moziserver.repository.AnimalMentionRepository;
 import com.mozi.moziserver.repository.AnimalRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -17,6 +23,7 @@ public class AnimalService {
 
     private final AnimalRepository animalRepository;
     private final AnimalItemRepository animalItemRepository;
+    private final AnimalMentionRepository animalMentionRepository;
 
     public Animal getAnimal(Long seq) {
 
@@ -84,5 +91,13 @@ public class AnimalService {
         AnimalItem animalItem = animalItemRepository.findByAnimalAndTurn(animal, itemTurn + 1)
                 .orElseThrow();
         return animalItem.getAcquisitionRequiredPoint();
+    }
+
+    // -------------------- -------------------- animal mention -------------------- -------------------- //
+    public List<String> getAnimalMentionListByAnimalAndItemAndPoint(Long animalSeq, Integer itemTurn, Integer userPoint) {
+
+        Optional<AnimalMention> animalMention = animalMentionRepository.findByAnimalSeqAndItemTurnAndPoint(animalSeq, itemTurn, userPoint);
+
+        return animalMention.map(mention -> Collections.singletonList(mention.getContent())).orElse(Constant.RANDOM_ANIMAL_MENTIONS);
     }
 }

--- a/src/main/java/com/mozi/moziserver/service/AnimalService.java
+++ b/src/main/java/com/mozi/moziserver/service/AnimalService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -96,8 +97,12 @@ public class AnimalService {
     // -------------------- -------------------- animal mention -------------------- -------------------- //
     public List<String> getAnimalMentionListByAnimalAndItemAndPoint(Long animalSeq, Integer itemTurn, Integer userPoint) {
 
-        Optional<AnimalMention> animalMention = animalMentionRepository.findByAnimalSeqAndItemTurnAndPoint(animalSeq, itemTurn, userPoint);
+        List<AnimalMention> animalMentionList = animalMentionRepository.findByAnimalSeqAndItemTurnAndUserWeekPoint(animalSeq, itemTurn, userPoint);
 
-        return animalMention.map(mention -> Collections.singletonList(mention.getContent())).orElse(Constant.RANDOM_ANIMAL_MENTIONS);
+        if (animalMentionList.isEmpty()) {
+            return Constant.RANDOM_ANIMAL_MENTIONS;
+        }
+
+        return animalMentionList.stream().map(AnimalMention::getContent).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/mozi/moziserver/service/AsyncService.java
+++ b/src/main/java/com/mozi/moziserver/service/AsyncService.java
@@ -99,7 +99,6 @@ public class AsyncService {
                     .fcmMessageType(fcmMessageType)
                     .expirationDateTime(expirationDateTime)
                     .islandSeq(lastDetailIsland.getSeq())
-                    .animalSeq(currentAnimal.getSeq())
                     .animalImgUrl(currentAnimal.getImgUrl())
                     .mentionList(animalMentions)
                     .build();
@@ -117,7 +116,6 @@ public class AsyncService {
                     .fcmMessageType(fcmMessageType)
                     .expirationDateTime(expirationDateTime)
                     .islandSeq(lastDetailIsland.getSeq())
-                    .animalSeq(nextAnimal.getSeq())
                     .animalImgUrl(nextAnimal.getImgUrl())
                     .mentionList(animalMentions)
                     .build();

--- a/src/main/java/com/mozi/moziserver/service/AsyncService.java
+++ b/src/main/java/com/mozi/moziserver/service/AsyncService.java
@@ -1,13 +1,18 @@
 package com.mozi.moziserver.service;
 
+import com.mozi.moziserver.httpException.ResponseError;
+import com.mozi.moziserver.model.AnimalMentionFcmMessage;
 import com.mozi.moziserver.model.entity.*;
 import com.mozi.moziserver.model.mappedenum.FcmMessageType;
+import com.mozi.moziserver.repository.IslandRepository;
+import com.mozi.moziserver.repository.UserIslandRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 
@@ -19,8 +24,10 @@ public class AsyncService {
     private final UserRewardService userRewardService;
     private final AnimalService animalService;
     private final PostboxMessageAnimalService postboxMessageAnimalService;
-    private final IslandService islandService;
     private final FcmService fcmService;
+
+    private final IslandRepository islandRepository;
+    private final UserIslandRepository userIslandRepository;
 
     @Async
     public void sendNewAnimalNotification(User user) {
@@ -42,9 +49,9 @@ public class AsyncService {
         }
 
         //유저의 현재 섬이 마지막 단계이면 알림 보내지 않음
-        UserIsland lastUserIsland = islandService.getLastUserIsland(user);
+        UserIsland lastUserIsland = getLastUserIsland(user);
         DetailIsland lastDetailIsland = lastUserIsland.getDetailIsland();
-        if (islandService.isLastDetailIslandOfIsland(lastDetailIsland)) {
+        if (isLastDetailIslandOfIsland(lastDetailIsland)) {
             return;
         }
 
@@ -58,6 +65,81 @@ public class AsyncService {
             LocalDate movingDate = now.minusDays(now.getDayOfWeek().getValue()).plusDays(7);
             fcmService.sendDateMessageToUser(user, movingDate, FcmMessageType.MOVING_DAY_OF_NEW_ANIMAL);
         }
+    }
 
+    // -------------------- -------------------- animal mention -------------------- --------------------
+    @Async
+    public void sendAnimalMention(User user) {
+
+        // 저번주 일요일부터 현재까지 모은 포인트
+        Integer thisWeekUserRewardPoint = userRewardService.getUserPointOfThisWeek(user);
+
+        // 섬의 마지막 단계면 보내지 않음
+        UserIsland lastUserIsland = getLastUserIsland(user);
+        DetailIsland lastDetailIsland = lastUserIsland.getDetailIsland();
+        if (isLastDetailIslandOfIsland(lastDetailIsland)) {
+            return;
+        }
+
+        // 유저의 일주일 획득 포인트가 리셋되는 날로 expirationDateTime 초기화하기
+        // 만약 현재가 일요일인데 21시 이후이면 다가오는 일요일 21시로
+        // 만약 현재가 일요일인데 21시 이전이면 오늘 일요일 21시로
+        FcmMessageType fcmMessageType = FcmMessageType.ANIMAL_MENTION;
+        LocalDateTime expirationDateTime = userRewardService.getNextResetTimeOfUserWeekPoint();
+
+        if (lastDetailIsland.getItemTurn() == animalService.getLastItemTurnByIslandAndAnimalTurn(lastDetailIsland.getIsland().getSeq(), lastDetailIsland.getAnimalTurn())) {
+
+            // 1. 현재 단계의 동물이 마지막 단계이면(아이템을 모두 가지고 있으면) 다음 동물의 멘션 보내기
+            // 다음 단계 동물 조회 -> 해당 동물과 유저 포인트에 따른 메세지 보내기
+            Animal currentAnimal = animalService.getAnimalByIslandAndTurn(lastDetailIsland.getIsland().getSeq(), lastDetailIsland.getAnimalTurn());
+
+            List<String> animalMentions = animalService.getAnimalMentionListByAnimalAndItemAndPoint(currentAnimal.getSeq(), lastDetailIsland.getItemTurn(), thisWeekUserRewardPoint);
+
+            AnimalMentionFcmMessage animalMentionMessage = AnimalMentionFcmMessage.builder()
+                    .fcmMessageType(fcmMessageType)
+                    .expirationDateTime(expirationDateTime)
+                    .islandSeq(lastDetailIsland.getSeq())
+                    .animalSeq(currentAnimal.getSeq())
+                    .animalImgUrl(currentAnimal.getImgUrl())
+                    .mentionList(animalMentions)
+                    .build();
+
+            fcmService.sendMessageToUser(user, animalMentionMessage);
+        } else {
+
+            // 2. 현재 단계 동물의 마지막 단계가 아니면 현재 동물의 멘션 보내기
+            // 현재 동물 조회 -> 해당 동물과 유저 포인트에 따른 메세지 보내기
+            Animal nextAnimal = animalService.getAnimalByIslandAndTurn(lastDetailIsland.getIsland().getSeq(), lastDetailIsland.getAnimalTurn() + 1);
+
+            List<String> animalMentions = animalService.getAnimalMentionListByAnimalAndItemAndPoint(nextAnimal.getSeq(), lastDetailIsland.getItemTurn(), thisWeekUserRewardPoint);
+
+            AnimalMentionFcmMessage animalMentionMessage = AnimalMentionFcmMessage.builder()
+                    .fcmMessageType(fcmMessageType)
+                    .expirationDateTime(expirationDateTime)
+                    .islandSeq(lastDetailIsland.getSeq())
+                    .animalSeq(nextAnimal.getSeq())
+                    .animalImgUrl(nextAnimal.getImgUrl())
+                    .mentionList(animalMentions)
+                    .build();
+
+            fcmService.sendMessageToUser(user, animalMentionMessage);
+        }
+    }
+
+    private UserIsland getLastUserIsland(User user) {
+
+        return userIslandRepository.findTopByUserOrderByIsland(user);
+    }
+
+    private boolean isLastDetailIslandOfIsland(DetailIsland detailIsland) {
+
+        Island island = islandRepository.findById(detailIsland.getIsland().getSeq())
+                .orElseThrow(ResponseError.NotFound.ISLAND_NOT_EXISTS::getResponseException);
+
+        int lastAnimalTurn = animalService.getLastAnimalTurnByIsland(island.getSeq());
+        int LastItemTurn = animalService.getLastItemTurnByIslandAndAnimalTurn(
+                detailIsland.getIsland().getSeq(), lastAnimalTurn);
+
+        return lastAnimalTurn == detailIsland.getAnimalTurn() && LastItemTurn == detailIsland.getItemTurn();
     }
 }

--- a/src/main/java/com/mozi/moziserver/service/ConfirmService.java
+++ b/src/main/java/com/mozi/moziserver/service/ConfirmService.java
@@ -93,8 +93,8 @@ public class ConfirmService {
 
         });
 
-        //이삿날 푸시 알림 보내기
         asyncService.sendNewAnimalNotification(user);
+        asyncService.sendAnimalMention(user);
     }
 
     public List<Confirm> getConfirmList(User user, ReqList req, ConfirmListType confirmListType) {
@@ -310,7 +310,7 @@ public class ConfirmService {
         List<Confirm> confirmList = new ArrayList<>();
 
         if (confirmListType.equals(ConfirmListType.RECENT)) {
-            LocalDateTime startDateTime = LocalDateTime.of(now.getYear(), now.getMonthValue(), now.getDayOfMonth()-6, 0, 0, 0);
+            LocalDateTime startDateTime = LocalDateTime.of(now.getYear(), now.getMonthValue(), now.getDayOfMonth() - 6, 0, 0, 0);
             confirmList = confirmRepository.findByCreatedAt(startDateTime);
 
         } else if (confirmListType.equals(ConfirmListType.ALL)) {

--- a/src/main/java/com/mozi/moziserver/service/IslandService.java
+++ b/src/main/java/com/mozi/moziserver/service/IslandService.java
@@ -27,6 +27,7 @@ public class IslandService {
     private final UserRewardService userRewardService;
     private final PostboxMessageAnimalService postboxMessageAnimalService;
     private final AnimalService animalService;
+    private final AsyncService asyncService;
     
     private final IslandRepository islandRepository;
     private final UserIslandRepository userIslandRepository;
@@ -106,6 +107,9 @@ public class IslandService {
         userIslandRepository.save(userIsland);
 
         postboxMessageAnimalService.createFirstMessageInIsland(user, islandSeq);
+
+        asyncService.sendNewAnimalNotification(user);
+        asyncService.sendAnimalMention(user);
     }
 
     @Transactional

--- a/src/main/java/com/mozi/moziserver/service/ScheduleService.java
+++ b/src/main/java/com/mozi/moziserver/service/ScheduleService.java
@@ -44,6 +44,7 @@ public class ScheduleService {
 //    @Scheduled(initialDelay = 1000L, fixedDelay = 100000000000000L)
     @Scheduled(cron = "0 0 0 * * *")
     public void updateUserChallenge() {
+
         final LocalDate today = LocalDate.now();
 
         // TODO return 되는 값은 로그로 남긴다.
@@ -53,6 +54,7 @@ public class ScheduleService {
     }
 
     public void updateUserChallengeDoingToEnd(final LocalDate date) {
+
         List<UserChallenge> endedUserChallengeList = userChallengeRepository.findAllByStateAndStartDate(UserChallengeStateType.DOING, date.minusDays(7));
 
         for (UserChallenge userChallenge : endedUserChallengeList) {
@@ -68,10 +70,11 @@ public class ScheduleService {
             });
 
             fcmService.sendMessageToUser(userChallenge.getUser(), FcmMessageType.END_USER_CHALLENGE_MESSAGE);
+            asyncService.sendAnimalMention(userChallenge.getUser());
         }
     }
 
-//    For test
+    //    For test
 //    @Scheduled(initialDelay = 1000L, fixedDelay = 100000000000000L)
     @Scheduled(cron = "0 0 21 ? * SUN")
     public void updatePostboxAnimalByUserPointRecord() {
@@ -113,12 +116,15 @@ public class ScheduleService {
             if (newMessageCnt.get() > 0) {
                 fcmService.sendMessageToUser(user, FcmMessageType.POSTBOX_MESSAGE_ANIMAL_NEW_ARRIVED);
             }
+
             fcmService.sendMessageToUser(user, FcmMessageType.NEW_POST_BOX_MESSAGE);
             fcmService.sendMessageToUser(user, FcmMessageType.POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM);
+            asyncService.sendAnimalMention(user);
         }
     }
 
     private void withTransaction(Runnable runnable) {
+
         DefaultTransactionDefinition definition = new DefaultTransactionDefinition();
 
         TransactionStatus status = transactionManager.getTransaction(definition);

--- a/src/main/java/com/mozi/moziserver/service/UserRewardService.java
+++ b/src/main/java/com/mozi/moziserver/service/UserRewardService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 @Service
@@ -90,5 +91,17 @@ public class UserRewardService {
         return thisWeekUserPoint;
     }
 
-}
+    /**
+     * @return 다가오는 일요일 9시
+     */
+    public LocalDateTime getNextResetTimeOfUserWeekPoint() {
 
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.getDayOfWeek().equals(DayOfWeek.SUNDAY) && now.isBefore(now.withHour(21).withMinute(0).withSecond(0))) {
+            return now.withHour(21).withMinute(0).withSecond(0);
+        }
+
+        return now.with(TemporalAdjusters.next(DayOfWeek.SUNDAY)).withHour(21).withMinute(0).withSecond(0);
+    }
+}

--- a/src/test/java/com/mozi/moziserver/repository/AnimalMentionRepositoryTest.java
+++ b/src/test/java/com/mozi/moziserver/repository/AnimalMentionRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.mozi.moziserver.repository;
+
+import com.mozi.moziserver.model.entity.AnimalMention;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class AnimalMentionRepositoryTest {
+
+    @Autowired
+    private AnimalMentionRepository animalMentionRepository;
+
+    @Test
+    @DisplayName("AnimalMention 적절하게 조회되는지 확인")
+    void findAnimalMention() {
+        AnimalMention animalMention = animalMentionRepository.findByAnimalSeqAndItemTurnAndPoint(2L, 2, 5);
+
+        Assertions.assertEquals(2L, animalMention.getAnimal().getSeq());
+        Assertions.assertEquals(2, animalMention.getItemTurn());
+        Assertions.assertEquals("밤에도 낮에도 선명한 제로리를 보고싶어!", animalMention.getContent());
+    }
+}

--- a/src/test/java/com/mozi/moziserver/repository/AnimalMentionRepositoryTest.java
+++ b/src/test/java/com/mozi/moziserver/repository/AnimalMentionRepositoryTest.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.util.*;
+
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class AnimalMentionRepositoryTest {
@@ -18,10 +20,10 @@ public class AnimalMentionRepositoryTest {
     @Test
     @DisplayName("AnimalMention 적절하게 조회되는지 확인")
     void findAnimalMention() {
-        AnimalMention animalMention = animalMentionRepository.findByAnimalSeqAndItemTurnAndPoint(2L, 2, 5);
+        AnimalMention animalMention = animalMentionRepository.findByAnimalSeqAndItemTurnAndUserWeekPoint(2L, 2, 5).get(0);
 
         Assertions.assertEquals(2L, animalMention.getAnimal().getSeq());
         Assertions.assertEquals(2, animalMention.getItemTurn());
-        Assertions.assertEquals("밤에도 낮에도 선명한 제로리를 보고싶어!", animalMention.getContent());
+        Assertions.assertEquals("한 번 더 제로하면 연못이 온대요!", animalMention.getContent());
     }
 }


### PR DESCRIPTION
## | 1. 개요 
- #140 

## | 2. 기능 및 설계
### 1) 요구사항
Home 화면(섬 화면) 오른쪽 하단에 다음 도착할 동물의 말풍선 알림이 나타냅니다. 이번주(일요일 오후 9시 ~ 일요일 오후 9시, 총 일주일)동안 사용자가 획득한 포인트가 변화할 때 알림 메시지가 변합니다.


### 2) 설계
1. ERD
animal_mention 테이블을 추가하여 말풍선 알림 메시지 내용을 저장합니다.

2. 서비스 로직
말풍선 알림 메시지는 사용자의 이번주 획득 포인트에 따라 변화함으로 사용자의 해당 포인트가 변화하는 모든 순간이 푸시 알림을 보내는 시점입니다.

- 매주 일요일 오후 9시
- 사용자가 챌린지 인증 시
- 일주일 챌린지 완료 시점에 추가 보상 기준을 충족했을 시 (자정)
- 사용자가 새로운 섬을 오픈했을 시

3.  푸시 알림 내용
{
  "island_seq": 1,
  "animal_img_url": "https://sfksdjfksdjfds.png",
  "send_at": "2023-06-11T16:20:45.224Z",
  "expiration_date_time": "2023-06-11T16:20:45.224Z",
  "mentions": [
    "제가 이사갈 수 있도록 제로해주세요!"
  ]
}

## | 3. 구현 (세부 작업 내용)
### 1) animal_mention 테이블 생성 및 데이터 추가
[ animal_mention ] 
- seq
- animal_seq
- item_turn : 동물의 아이템 레벨
- start_point
- range_point : start_point <= (사용자의 일주일 획득 포인트) < start_point + range_point 일 때, 해당 말풍선을 보내기 위함
- content : 말풍선 내용

### 2) FcmMessage, AnimalMentionFcmMessage 클래스 정의
FCM 메시지의 공통되는 내용을 가지고 있는 FcmMessage와 이를 상속받는 AnimalFcmMessage를 정의

### 3) 아래 상황에서 AnimalMentionFcmMessage를 보내는 로직 작성 -> AsyncService의 sendAnimalMention 함수
- 매주 일요일 오후 9시
- 사용자가 챌린지 인증 시
- 일주일 챌린지 완료 시점에 추가 보상 기준을 충족했을 시 (자정)
- 사용자가 새로운 섬을 오픈했을 시

## | 4. 기타 전달사항
1. 섬 오픈시, AnimalMention 푸시 알림을 보내는 AsyncService의 메서드를 호출했더니 IslandService와 AsyncService 사이 순환 참조 발생 -> 임시적으로 AsynService가 IslandService가 아닌 IslandRepository를 참조하도록 하여 해결 
=>  **Service 설계 원칙에 대한 논의 필요 Ex. 서비스 간 참조 방향성 등**

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#140 -> dev