### PR TITLE
Feature/#139

### DIFF
--- a/src/main/java/com/mozi/moziserver/common/Constant.java
+++ b/src/main/java/com/mozi/moziserver/common/Constant.java
@@ -98,4 +98,6 @@ public interface Constant {
     int lastTurnOfAnimalItem = 2;
 
     int totalImagesPerIsland = 11;
+
+    int TUTORIAL_ANIMAL_ITEM_POINT = 5;
 }

--- a/src/main/java/com/mozi/moziserver/service/EmailAuthService.java
+++ b/src/main/java/com/mozi/moziserver/service/EmailAuthService.java
@@ -291,8 +291,8 @@ public class EmailAuthService {
                 user.setEmail(userAuth.getId());
                 userRepository.save(user);
 
-                islandService.firstCreateUserIsland(user);
-                userRewardService.firstCreateUserReward(user);
+                islandService.createUserIslandForJoin(user);
+                userRewardService.createUserRewardForJoin(user);
             });
         } catch (DataIntegrityViolationException e) {
             if (JpaUtil.isDuplicateKeyException(e)) {

--- a/src/main/java/com/mozi/moziserver/service/IslandService.java
+++ b/src/main/java/com/mozi/moziserver/service/IslandService.java
@@ -14,7 +14,6 @@ import com.mozi.moziserver.repository.UserIslandRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -23,11 +22,11 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class IslandService {
-    
+
     private final UserRewardService userRewardService;
     private final PostboxMessageAnimalService postboxMessageAnimalService;
     private final AnimalService animalService;
-    
+
     private final IslandRepository islandRepository;
     private final UserIslandRepository userIslandRepository;
     private final DetailIslandRepository detailIslandRepository;
@@ -38,7 +37,7 @@ public class IslandService {
         return islandRepository.findById(seq)
                 .orElseThrow(ResponseError.NotFound.ISLAND_NOT_EXISTS::getResponseException);
     }
-    
+
     public List<Island> getIslandListOrderBySeq() {
 
         return islandRepository.findAllByOrderBySeqAsc();
@@ -52,8 +51,13 @@ public class IslandService {
     }
 
     public DetailIsland getFirstDetailIslandOfIsland(Long islandSeq) {
-
         return detailIslandRepository.findByIslandSeqAndAnimalTurnAndItemTurn(islandSeq, 0, 0)
+                .orElseThrow(ResponseError.NotFound.DETAIL_ISLAND_NOT_EXISTS::getResponseException);
+    }
+
+    public DetailIsland getDetailIslandForJoin() {
+        //회원가입하자마자 튜토리얼을 고려
+        return detailIslandRepository.findByIslandSeqAndAnimalTurnAndItemTurn(1L, 1, 1)
                 .orElseThrow(ResponseError.NotFound.DETAIL_ISLAND_NOT_EXISTS::getResponseException);
     }
 
@@ -85,15 +89,10 @@ public class IslandService {
 
         return userIslandRepository.findTopByUserOrderByIsland(user);
     }
-    
+
     public List<UserIsland> getUserIslandListOrderByIslandSeq(User user) {
 
         return userIslandRepository.findAllByUserOrderByIsland(user);
-    }
-
-    public void firstCreateUserIsland(User user) {
-
-        createUserIsland(user, 1L);
     }
 
     public void createUserIsland(User user, Long islandSeq) {
@@ -105,7 +104,21 @@ public class IslandService {
                 .build();
         userIslandRepository.save(userIsland);
 
-        postboxMessageAnimalService.createFirstMessageInIsland(user, islandSeq);
+        postboxMessageAnimalService.createFirstPostboxMessageAnimal(user, islandSeq);
+
+    }
+
+    @Transactional
+    public void createUserIslandForJoin(User user) {
+
+        DetailIsland detailIsland = getDetailIslandForJoin();
+        UserIsland userIsland = UserIsland.builder()
+                .detailIsland(detailIsland)
+                .user(user)
+                .build();
+        userIslandRepository.save(userIsland);
+
+        postboxMessageAnimalService.createPostboxMessageAnimalForJoin(user, 1L);
     }
 
     @Transactional

--- a/src/main/java/com/mozi/moziserver/service/PostboxMessageAnimalService.java
+++ b/src/main/java/com/mozi/moziserver/service/PostboxMessageAnimalService.java
@@ -77,7 +77,6 @@ public class PostboxMessageAnimalService {
 
     }
 
-    @Transactional
     public void createPostboxMessageAnimal(User user, Animal animal) {
 
         PostboxMessageAnimal postboxMessageAnimal = PostboxMessageAnimal.builder()
@@ -91,9 +90,18 @@ public class PostboxMessageAnimalService {
         userNoticeService.upsertUserNotice(user, UserNoticeType.POSTBOX_MESSAGE_ANIMAL_NEW_ARRIVED, postboxMessageAnimal.getSeq());
     }
 
-    public void createFirstMessageInIsland(User user, Long islandSeq) {
+    public void createFirstPostboxMessageAnimal(User user, Long islandSeq) {
 
         Animal animal = animalService.getAnimalByIslandAndTurn(islandSeq, 1);
+        createPostboxMessageAnimal(user, animal);
+    }
+
+    public void createPostboxMessageAnimalForJoin(User user, Long islandSeq) {
+        //Animal : 달팽이, turn : 1
+        createTutorialPostboxMessage(user, islandSeq);
+
+        //Animal : 수달, turn : 2
+        Animal animal = animalService.getAnimalByIslandAndTurn(islandSeq, 2);
         createPostboxMessageAnimal(user, animal);
     }
 
@@ -161,5 +169,24 @@ public class PostboxMessageAnimalService {
         }
 
         return 0;
+    }
+
+    public void createTutorialPostboxMessage(User user, Long islandSeq) {
+
+        Animal animal = animalService.getAnimalByIslandAndTurn(islandSeq, 1);
+        PostboxMessageAnimal postboxMessageAnimal = PostboxMessageAnimal.builder()
+                .user(user)
+                .animal(animal)
+                .checkedState(true)
+                .build();
+        postboxMessageAnimalRepository.save(postboxMessageAnimal);
+
+        AnimalItem animalItem = animalService.getAnimalItem(animal, 1);
+        PostboxMessageAnimalItem postboxMessageAnimalItem = PostboxMessageAnimalItem.builder()
+                .animalItem(animalItem)
+                .postboxMessageAnimal(postboxMessageAnimal)
+                .build();
+        postboxMessageAnimalItemRepository.save(postboxMessageAnimalItem);
+
     }
 }

--- a/src/main/java/com/mozi/moziserver/service/UserRewardService.java
+++ b/src/main/java/com/mozi/moziserver/service/UserRewardService.java
@@ -1,5 +1,6 @@
 package com.mozi.moziserver.service;
 
+import com.mozi.moziserver.common.Constant;
 import com.mozi.moziserver.model.entity.User;
 import com.mozi.moziserver.model.entity.UserPointRecord;
 import com.mozi.moziserver.model.entity.UserReward;
@@ -66,11 +67,11 @@ public class UserRewardService {
         return sumPoint;
     }
 
-    public void firstCreateUserReward(User user) {
+    public void createUserRewardForJoin(User user) {
 
         UserReward userReward = UserReward.builder()
                 .user(user)
-                .point(0)
+                .point(Constant.TUTORIAL_ANIMAL_ITEM_POINT)
                 .build();
         userRewardRepository.save(userReward);
     }

--- a/src/main/java/com/mozi/moziserver/service/UserService.java
+++ b/src/main/java/com/mozi/moziserver/service/UserService.java
@@ -217,8 +217,8 @@ public class UserService {
 
             userAuthRepository.save(userAuth);
 
-            islandService.firstCreateUserIsland(user);
-            userRewardService.firstCreateUserReward(user);
+            islandService.createUserIslandForJoin(user);
+            userRewardService.createUserRewardForJoin(user);
         });
     }
 


### PR DESCRIPTION
## 개요 
- #139 
- 튜토리얼(동물-참달팽이) 추가로 인한 회원가입 시 프로세스 수정

### 세부 작업 내용
- 회원가입 시 두가지 상황 고려 : 이메일 가입과 소셜 로그인
- 튜토리얼 동물 (turn =1)에 대한 PostboxMessageAnimal과 PostboxMessageAnimalItem 생성
- 튜토리얼 동물에 대한 아이템 필요 포인트 생성
- 다음 동물(turn = 2)에 대한 PostboxMessageAnimal과 UserNotice 생성
- 회원가입 시 사용되는 메소드 이름의 postfix를 ForJoin으로 수정

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#139 -> main

### 테스트 결과 (optional)
이메일 가입인 경우는 테스트 성공 