### PR TITLE
LLM을 이용한 악성 유저가 업로드한 인증 이미지 BLOCK 처리

### DIFF
--- a/src/main/java/com/mozi/moziserver/adminService/AdminConfirmService.java
+++ b/src/main/java/com/mozi/moziserver/adminService/AdminConfirmService.java
@@ -4,6 +4,7 @@ import com.mozi.moziserver.httpException.ResponseError;
 import com.mozi.moziserver.model.entity.Confirm;
 import com.mozi.moziserver.model.mappedenum.ConfirmStateType;
 import com.mozi.moziserver.repository.ConfirmRepository;
+import com.mozi.moziserver.service.ConfirmBlockHistoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import java.util.List;
 public class AdminConfirmService {
 
     private final ConfirmRepository confirmRepository;
+    private final ConfirmBlockHistoryService confirmBlockHistoryService;
 
     public Confirm getById(Long seq) {
 
@@ -38,6 +40,8 @@ public class AdminConfirmService {
         Confirm confirm = getById(seq);
         confirm.setState(confirmSateType);
         confirmRepository.save(confirm);
+
+        saveHistoryIfBlocked(confirm);
     }
 
     public void deleteConfirm(Long seq) {
@@ -45,5 +49,11 @@ public class AdminConfirmService {
         Confirm confirm = getById(seq);
         confirm.setState(ConfirmStateType.DELETED);
         confirmRepository.save(confirm);
+    }
+
+    private void saveHistoryIfBlocked(Confirm confirm) {
+        if (confirm.getState() == ConfirmStateType.BLOCKED) {
+            confirmBlockHistoryService.saveBlockHistory(confirm.getSeq());
+        }
     }
 }

--- a/src/main/java/com/mozi/moziserver/common/Constant.java
+++ b/src/main/java/com/mozi/moziserver/common/Constant.java
@@ -77,12 +77,12 @@ public interface Constant {
     String NICKNAME_REGEX = "^[ㄱ-ㅎ가-힣A-Za-z0-9!@#$%^&*(),.?\":{}|<>]{1,8}$";
 
     List<List<String>> EMAIL_DOMAIN_GROUPS = Arrays.asList(
-            Arrays.asList("gmail.com"),
-            Arrays.asList("naver.com"),
+            List.of("gmail.com"),
+            List.of("naver.com"),
             Arrays.asList("daum.net", "hanmail.net"),
-            Arrays.asList("kakao.com"),
+            List.of("kakao.com"),
             Arrays.asList("icloud.com", "me.com", "mac.com"),
-            Arrays.asList("devwon.com")
+            List.of("devwon.com")
     );
 
     List<String> IMAGE_MIME_TYPE_LIST = List.of("image/png", "image/jpeg");
@@ -100,4 +100,9 @@ public interface Constant {
     int totalImagesPerIsland = 11;
 
     int TUTORIAL_ANIMAL_ITEM_POINT = 5;
+
+    int GITHUB_MODELS_MAX_TOKENS = 8000;
+    String GITHUB_MODELS_MODEL_NAME = "gpt-4o-mini";
+    String GITHUB_MODELS_CHALLENGE_PROMPT = "이 사진이 제로웨이스트 활동인 '%s' 실천한 인증 사진이 맞으면 'Y' 아니라면 'N'으로 대답해줘.";
+    String GITHUB_MODELS_ROLE = "user";
 }

--- a/src/main/java/com/mozi/moziserver/config/GithubModelsConfig.java
+++ b/src/main/java/com/mozi/moziserver/config/GithubModelsConfig.java
@@ -1,0 +1,18 @@
+package com.mozi.moziserver.config;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+public class GithubModelsConfig {
+    @Value("${github.models.apiKey}")
+    private String githubModelsApiKey;
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            requestTemplate.header("Authorization", "Bearer " + githubModelsApiKey);
+            requestTemplate.header("Content-Type", "application/json");
+        };
+    }
+}

--- a/src/main/java/com/mozi/moziserver/model/entity/ConfirmBlockHistory.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ConfirmBlockHistory.java
@@ -1,0 +1,21 @@
+package com.mozi.moziserver.model.entity;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity(name = "confirm_block_history")
+public class ConfirmBlockHistory extends AbstractTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    private Long confirmSeq;
+}

--- a/src/main/java/com/mozi/moziserver/model/req/ReqConfirmCheck.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqConfirmCheck.java
@@ -1,0 +1,55 @@
+package com.mozi.moziserver.model.req;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ReqConfirmCheck {
+    @JsonProperty("max_tokens")
+    private int maxTokens;
+    private String model;
+    private List<Message> messages;
+
+    @Builder
+    @Getter
+    public static class Message {
+        String role;
+        @JsonProperty("content")
+        List<Content> contentList;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = TextContent.class, name = "text"),
+            @JsonSubTypes.Type(value = ImageContent.class, name = "image_url")
+    })
+    public static abstract class Content {
+        String type;
+    }
+
+    @Builder
+    @Getter
+    public static class TextContent extends Content {
+        String text;
+    }
+
+    @Builder
+    @Getter
+    public static class ImageContent extends Content {
+        @JsonProperty("image_url")
+        ImageUrl imageUrl;
+    }
+
+    @Builder
+    @Getter
+    public static class ImageUrl {
+        String url;
+    }
+
+}

--- a/src/main/java/com/mozi/moziserver/repository/ConfirmBlockHistoryRepository.java
+++ b/src/main/java/com/mozi/moziserver/repository/ConfirmBlockHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.mozi.moziserver.repository;
+
+import com.mozi.moziserver.model.entity.ConfirmBlockHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConfirmBlockHistoryRepository extends JpaRepository<ConfirmBlockHistory, Long> {
+}

--- a/src/main/java/com/mozi/moziserver/rest/GithubModelsClient.java
+++ b/src/main/java/com/mozi/moziserver/rest/GithubModelsClient.java
@@ -1,0 +1,51 @@
+package com.mozi.moziserver.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mozi.moziserver.config.GithubModelsConfig;
+import com.mozi.moziserver.model.req.ReqConfirmCheck;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@FeignClient(name = "githubModelsClient", url = "${github.models.url}",
+        configuration = GithubModelsConfig.class)
+public interface GithubModelsClient {
+    @PostMapping("/chat/completions")
+    ResConfirmCheck verifyConfirmForChallengeName(
+            @RequestBody ReqConfirmCheck reqChallgeCheck
+    );
+
+    @Getter
+    @Setter
+    class ResConfirmCheck {
+        private List<Choice> choices;
+
+        public boolean isAllContentN() {
+            return choices != null && choices.stream().allMatch(Choice::isContentN);
+        }
+    }
+
+    @Getter
+    @Setter
+    class Choice {
+        @JsonProperty("finish_reason")
+        private String finishReason;
+        private int index;
+        private Message message;
+
+        public boolean isContentN() {
+            return "N".equals(message.getContent());
+        }
+    }
+
+    @Getter
+    @Setter
+    class Message {
+        private String content;
+        private String role;
+    }
+}

--- a/src/main/java/com/mozi/moziserver/rest/SlackClient.java
+++ b/src/main/java/com/mozi/moziserver/rest/SlackClient.java
@@ -1,0 +1,11 @@
+package com.mozi.moziserver.rest;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "slackClient", url = "${slack.webhook.blocked-info}")
+public interface SlackClient {
+    @PostMapping
+    void sendMessage(@RequestBody String payload);
+}

--- a/src/main/java/com/mozi/moziserver/service/AsyncService.java
+++ b/src/main/java/com/mozi/moziserver/service/AsyncService.java
@@ -1,7 +1,12 @@
 package com.mozi.moziserver.service;
 
+import com.mozi.moziserver.adminService.AdminConfirmService;
 import com.mozi.moziserver.model.entity.*;
+import com.mozi.moziserver.model.mappedenum.ConfirmStateType;
 import com.mozi.moziserver.model.mappedenum.FcmMessageType;
+import com.mozi.moziserver.model.req.ReqConfirmCheck;
+import com.mozi.moziserver.rest.GithubModelsClient;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -10,6 +15,9 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+
+import static com.mozi.moziserver.common.Constant.*;
 
 @Slf4j
 @Service
@@ -21,6 +29,8 @@ public class AsyncService {
     private final PostboxMessageAnimalService postboxMessageAnimalService;
     private final IslandService islandService;
     private final FcmService fcmService;
+    private final GithubModelsClient githubModelsClient;
+    private final AdminConfirmService adminConfirmService;
 
     @Async
     public void sendNewAnimalNotification(User user) {
@@ -59,5 +69,41 @@ public class AsyncService {
             fcmService.sendDateMessageToUser(user, movingDate, FcmMessageType.MOVING_DAY_OF_NEW_ANIMAL);
         }
 
+    }
+
+    @Async
+    void verifyConfirm(Long confirmSeq, String imgUrl, String challengeName) {
+        String formattedText = String.format(GITHUB_MODELS_CHALLENGE_PROMPT, challengeName);
+
+        ReqConfirmCheck reqConfirmCheck = ReqConfirmCheck.builder()
+                .maxTokens(GITHUB_MODELS_MAX_TOKENS)
+                .model(GITHUB_MODELS_MODEL_NAME)
+                .messages(List.of(ReqConfirmCheck.Message.builder()
+                        .role(GITHUB_MODELS_ROLE)
+                        .contentList(List.of(ReqConfirmCheck.TextContent.builder()
+                                        .text(formattedText)
+                                        .build(),
+                                ReqConfirmCheck.ImageContent.builder()
+                                        .imageUrl(ReqConfirmCheck.ImageUrl.builder()
+                                                .url(imgUrl)
+                                                .build())
+                                        .build()))
+                        .build()))
+                .build();
+
+        Optional<GithubModelsClient.ResConfirmCheck> resConfirmCheck;
+        try {
+            resConfirmCheck = Optional.of(githubModelsClient.verifyConfirmForChallengeName(reqConfirmCheck));
+        } catch (FeignException e) {
+            resConfirmCheck = Optional.empty();
+            log.error(e.getMessage(), e);
+        }
+
+        resConfirmCheck.ifPresent(res -> {
+            //제로 챌린지에 알맞지 않은 인증 이미지이면 BLOCKED 처리
+            if (res.isAllContentN()) {
+                adminConfirmService.updateConfirmState(confirmSeq, ConfirmStateType.BLOCKED);
+            }
+        });
     }
 }

--- a/src/main/java/com/mozi/moziserver/service/AsyncService.java
+++ b/src/main/java/com/mozi/moziserver/service/AsyncService.java
@@ -31,6 +31,7 @@ public class AsyncService {
     private final FcmService fcmService;
     private final GithubModelsClient githubModelsClient;
     private final AdminConfirmService adminConfirmService;
+    private final SlackNotiService slackNotiService;
 
     @Async
     public void sendNewAnimalNotification(User user) {
@@ -103,6 +104,7 @@ public class AsyncService {
             //제로 챌린지에 알맞지 않은 인증 이미지이면 BLOCKED 처리
             if (res.isAllContentN()) {
                 adminConfirmService.updateConfirmState(confirmSeq, ConfirmStateType.BLOCKED);
+                slackNotiService.sendConfirmBlockedMessage(challengeName, confirmSeq, imgUrl);
             }
         });
     }

--- a/src/main/java/com/mozi/moziserver/service/ConfirmBlockHistoryService.java
+++ b/src/main/java/com/mozi/moziserver/service/ConfirmBlockHistoryService.java
@@ -1,0 +1,21 @@
+package com.mozi.moziserver.service;
+
+import com.mozi.moziserver.model.entity.ConfirmBlockHistory;
+import com.mozi.moziserver.repository.ConfirmBlockHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ConfirmBlockHistoryService {
+    private final ConfirmBlockHistoryRepository confirmBlockHistoryRepository;
+
+    public void saveBlockHistory(Long confirmSeq) {
+        ConfirmBlockHistory confirmBlockHistory = ConfirmBlockHistory.builder()
+                .confirmSeq(confirmSeq)
+                .build();
+        confirmBlockHistoryRepository.save(confirmBlockHistory);
+    }
+}

--- a/src/main/java/com/mozi/moziserver/service/ConfirmService.java
+++ b/src/main/java/com/mozi/moziserver/service/ConfirmService.java
@@ -95,6 +95,9 @@ public class ConfirmService {
 
         //이삿날 푸시 알림 보내기
         asyncService.sendNewAnimalNotification(user);
+
+        //인증 이미지 검증
+        asyncService.verifyConfirm(confirm.getSeq(), imgUrl, challenge.getName());
     }
 
     public List<Confirm> getConfirmList(User user, ReqList req, ConfirmListType confirmListType) {

--- a/src/main/java/com/mozi/moziserver/service/SlackNotiService.java
+++ b/src/main/java/com/mozi/moziserver/service/SlackNotiService.java
@@ -1,0 +1,22 @@
+package com.mozi.moziserver.service;
+
+import com.mozi.moziserver.rest.SlackClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SlackNotiService {
+
+    private final SlackClient slackClient;
+
+    public void sendConfirmBlockedMessage(String challengeName,Long confirmSeq, String imgUrl) {
+        String payload = String.format(
+                "{\"text\": \"🔴 *[Challenge Image Blocked]*\\n- *Challenge Name:* `%s`\\n- *Confirm Seq:* `%s`\\n- *Image URL:* `<%s>`\\n\\n⚠️ 인증 이미지가 챌린지에 맞지 않아 차단되었습니다.\"}",
+                challengeName, confirmSeq, imgUrl
+        );
+        slackClient.sendMessage(payload);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,7 @@ sentry:
   stacktrace:
     app-packages:
       - com.mozi.moziserver
+
+slack:
+  webhook:
+    blocked-info: ${SLACK_WEBHOOK_BLOCKED_INFO}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,11 @@ social:
 jwt:
   key: ${JWT_KEY}
 
+github:
+  models:
+    url: https://models.inference.ai.azure.com
+    apiKey: ${GITHUB_MODELS_APIKEY}
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## 개요 
- Issue #151 
- LLM을 이용한 악성 유저가 업로드한 인증 이미지 BLOCK 처리

### 세부 작업 내용
- 인증 생성 시, 비동기로 gpt-4o-mini 모델 호출
- 모델 응답값을 바탕으로 인증 BLOCK 처리
- 히스토리 테이블 생성 (confirm_block_history)
- 히스토리 남기기
- blocked일 경우 슬랙 메세지 보내기
   - 운영,개발 서버에 slack webhook url 환경변수 추가

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#151 -> main

### 테스트 결과 (optional)
- 챌린지 이름과 맞지 않은 이미지로 인증했을 때, 아래 3가지 테스트 완료(confirm seq =183)
- 1.BLOCKED으로 state 값 변경
- 2.히스토리 테이블 데이터 생성
- 3.슬랙 메세지 전송 확인

### 특이 사항 (optional)
- 로컬 및 개발 서버에 환경변수 추가되었습니다.
