### PR TITLE
Feature/#154 SpringBoot 3 마이그레이션 

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,10 +24,10 @@ jobs:
           #         echo "GITHUB_ENV VALUE IS $GITHUB_ENV"
 
       ## jdk setting
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
 
       ## gradle caching

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,10 +24,10 @@ jobs:
 #         echo "GITHUB_ENV VALUE IS $GITHUB_ENV"
         
     ## jdk setting
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         
     ## gradle caching

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16-jdk
+FROM eclipse-temurin:17.0.13_11-jdk
 ARG JAR_FILE=/build/libs/MoziServer-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
 ENV TZ=Asia/Seoul

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.13_11-jdk
+FROM openjdk:17.0.2-jdk
 ARG JAR_FILE=/build/libs/MoziServer-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
 ENV TZ=Asia/Seoul

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17.0.2-jdk
+FROM eclipse-temurin:17.0.13_11-jdk
 ARG JAR_FILE=/build/libs/MoziServer-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
 ENV TZ=Asia/Seoul

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-    id 'org.springframework.boot' version '2.5.5'
+    id 'org.springframework.boot' version '2.7.7'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
 
 group = 'com.mozi'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 configurations {
     compileOnly {
@@ -19,7 +19,7 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2020.0.4")
+    set('springCloudVersion', "2021.0.8")
 }
 
 dependencies {
@@ -35,16 +35,16 @@ dependencies {
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws', version: '2.2.1.RELEASE', ext: 'pom'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.39'
 
-    implementation 'org.springframework.security:spring-security-oauth2-jose:5.6.1'
+    implementation 'org.springframework.security:spring-security-oauth2-jose:5.7.11'
 
     // 비속어 검색 (Aho-Corasick 알고리즘)
     implementation 'org.ahocorasick:ahocorasick:0.6.3'
 
     // QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:4.4.0'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
     annotationProcessor 'javax.persistence:javax.persistence-api'
     annotationProcessor 'javax.annotation:javax.annotation-api'
-    annotationProcessor 'com.querydsl:querydsl-apt:4.4.0:jpa'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jpa'
 
     // image type detect
     implementation 'org.apache.tika:tika-core:2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.7'
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'org.springframework.boot' version '3.2.6'
+    id 'io.spring.dependency-management' version '1.1.5'
     id 'java'
 }
 
@@ -19,7 +19,7 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2021.0.8")
+    set('springCloudVersion', "2023.0.0")
 }
 
 dependencies {
@@ -29,30 +29,31 @@ dependencies {
     implementation 'org.springframework.session:spring-session-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws', version: '2.2.1.RELEASE', ext: 'pom'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.39'
 
     implementation 'org.springframework.security:spring-security-oauth2-jose:5.7.11'
 
+    implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.78'
+
     // 비속어 검색 (Aho-Corasick 알고리즘)
     implementation 'org.ahocorasick:ahocorasick:0.6.3'
 
     // QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:5.0.0'
-    annotationProcessor 'javax.persistence:javax.persistence-api'
-    annotationProcessor 'javax.annotation:javax.annotation-api'
-    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jpa'
+    implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // image type detect
     implementation 'org.apache.tika:tika-core:2.3.0'
 
     implementation 'com.google.firebase:firebase-admin:9.0.0'
-
-    //Swagger
-    implementation 'io.springfox:springfox-boot-starter:3.0.0'
 
     implementation 'co.elastic.apm:apm-agent-api:1.34.0'
     implementation 'co.elastic.apm:apm-agent-attach:1.34.0'
@@ -62,7 +63,7 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     //developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'mysql:mysql-connector-java'
+    runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -79,11 +80,10 @@ test {
     useJUnitPlatform()
 }
 
-//QueryDSL
 sourceSets {
-    main {
-        java {
-            srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
-        }
-    }
+    main.java.srcDirs += ['src/main/generated']
+}
+
+clean{
+    delete file('src/main/generated')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,6 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-admin:9.0.0'
 
-    implementation 'co.elastic.apm:apm-agent-api:1.34.0'
-    implementation 'co.elastic.apm:apm-agent-attach:1.34.0'
-
     implementation 'io.sentry:sentry-spring-boot-starter:6.11.0'
     implementation 'io.sentry:sentry-logback:6.11.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-admin:9.0.0'
 
-    implementation 'io.sentry:sentry-spring-boot-starter:6.11.0'
-    implementation 'io.sentry:sentry-logback:6.11.0'
+    implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.12.1'
+    implementation 'io.sentry:sentry-logback:7.12.1'
 
     compileOnly 'org.projectlombok:lombok'
     //developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/mozi/moziserver/MoziServerApplication.java
+++ b/src/main/java/com/mozi/moziserver/MoziServerApplication.java
@@ -1,6 +1,5 @@
 package com.mozi.moziserver;
 
-import co.elastic.apm.attach.ElasticApmAttacher;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -15,7 +14,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class MoziServerApplication {
 
     public static void main(String[] args) {
-        ElasticApmAttacher.attach();
         SpringApplication.run(MoziServerApplication.class, args);
     }
 

--- a/src/main/java/com/mozi/moziserver/adminController/AdminAnimalController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminAnimalController.java
@@ -9,7 +9,7 @@ import com.mozi.moziserver.model.adminRes.AdminResAnimalList;
 import com.mozi.moziserver.model.entity.Animal;
 import com.mozi.moziserver.model.entity.AnimalItem;
 import com.mozi.moziserver.model.entity.Island;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -33,7 +33,7 @@ public class AdminAnimalController {
     private final AdminIslandService adminIslandService;
 
     // -------------------- -------------------- animal -------------------- -------------------- //
-    @ApiOperation("동물 하나 조회")
+    @Operation(summary = "동물 하나 조회")
     @GetMapping("/admin/animals/{seq}")
     public AdminResAnimal getAnimal(
             @PathVariable("seq") Long seq
@@ -45,7 +45,7 @@ public class AdminAnimalController {
         return AdminResAnimal.of(animal, animalItemList);
     }
 
-    @ApiOperation("동물 리스트 조회")
+    @Operation(summary = "동물 리스트 조회")
     @GetMapping("/admin/animals")
     public List<AdminResAnimalList> getAnimalList(
             @RequestParam(name = "keyword", required = false) Long keyword, //islandSeq
@@ -63,7 +63,7 @@ public class AdminAnimalController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("동물 생성")
+    @Operation(summary = "동물 생성")
     @PostMapping("/admin/animals")
     public ResponseEntity<Object> createAnimal(
             @RequestParam(name = "name") @NotBlank String name,
@@ -87,7 +87,7 @@ public class AdminAnimalController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("동물 수정")
+    @Operation(summary = "동물 수정")
     @PutMapping("/admin/animals/{seq}")
     public ResponseEntity<Object> updateAnimal(
             @PathVariable("seq") Long seq,
@@ -106,7 +106,7 @@ public class AdminAnimalController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("동물 삭제")
+    @Operation(summary = "동물 삭제")
     @DeleteMapping("/admin/animals/{seq}")
     public ResponseEntity<Object> deleteAnimal(
             @PathVariable("seq") Long seq
@@ -118,7 +118,7 @@ public class AdminAnimalController {
     }
 
     // -------------------- -------------------- AnimalItem -------------------- -------------------- //
-    @ApiOperation("동물 아이템 하나 조회")
+    @Operation(summary = "동물 아이템 하나 조회")
     @GetMapping("/admin/animal-items/{seq}")
     public AdminResAnimalItem getAnimalItem(
             @PathVariable("seq") Long seq
@@ -127,7 +127,7 @@ public class AdminAnimalController {
         return AdminResAnimalItem.of(adminAnimalService.getAnimalItem(seq));
     }
 
-    @ApiOperation("동물 아이템 리스트 조회")
+    @Operation(summary = "동물 아이템 리스트 조회")
     @GetMapping("/admin/animal-items")
     public List<AdminResAnimalItem> getAnimalItemList(
             @RequestParam(value = "animalSeq", required = false) Long animalSeq,
@@ -140,7 +140,7 @@ public class AdminAnimalController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("동물의 아이템 등록")
+    @Operation(summary = "동물의 아이템 등록")
     @PostMapping("/admin/animal-items")
     public ResponseEntity<Object> createPreparationItem(
             @RequestParam("animalSeq") Long animalSeq,
@@ -160,7 +160,7 @@ public class AdminAnimalController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("동물의 아이템 수정")
+    @Operation(summary = "동물의 아이템 수정")
     @PutMapping("/admin/animal-items/{seq}")
     public ResponseEntity<Object> updatePreparationItem(
             @PathVariable(value = "seq") Long itemSeq,
@@ -179,7 +179,7 @@ public class AdminAnimalController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("동물의 아이템 삭제")
+    @Operation(summary = "동물의 아이템 삭제")
     @DeleteMapping("/admin/animal-items/{seq}")
     public ResponseEntity<Object> deleteAnimalItem(
             @PathVariable(value = "seq") Long itemSeq

--- a/src/main/java/com/mozi/moziserver/adminController/AdminAnimalController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminAnimalController.java
@@ -17,9 +17,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/mozi/moziserver/adminController/AdminAuthenticationController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminAuthenticationController.java
@@ -16,10 +16,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 
 import static org.springframework.security.web.context.HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY;
 

--- a/src/main/java/com/mozi/moziserver/adminController/AdminAuthenticationController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminAuthenticationController.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.adminController;
 
 import com.mozi.moziserver.adminService.AdminUserService;
 import com.mozi.moziserver.model.adminReq.ReqAdminSignIn;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -31,7 +31,7 @@ public class AdminAuthenticationController {
 
     private final AdminUserService adminUserService;
 
-    @ApiOperation("관리자 로그인 (ID)")
+    @Operation(summary = "관리자 로그인 (ID)")
     @PostMapping(value = "/admin/signin", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Object> signInUser(
             @RequestBody @Valid ReqAdminSignIn req,

--- a/src/main/java/com/mozi/moziserver/adminController/AdminBoardController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminBoardController.java
@@ -11,8 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Max;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/mozi/moziserver/adminController/AdminBoardController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminBoardController.java
@@ -4,7 +4,7 @@ import com.mozi.moziserver.adminService.AdminBoardService;
 import com.mozi.moziserver.model.adminReq.ReqAdminPostboxMessageAdminCreate;
 import com.mozi.moziserver.model.adminRes.AdminResBoard;
 import com.mozi.moziserver.model.adminRes.AdminResPostboxMessageAdmin;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,7 +24,7 @@ public class AdminBoardController {
 
     private final AdminBoardService adminBoardService;
 
-    @ApiOperation("공지사항 리스트 조회")
+    @Operation(summary = "공지사항 리스트 조회")
     @GetMapping("/admin/boards")
     public List<AdminResBoard> getBoardList(
             @RequestParam(name = "pageNumber", required = false, defaultValue = "0") Integer pageNumber,
@@ -36,7 +36,7 @@ public class AdminBoardController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("공지사항 하나 조회")
+    @Operation(summary = "공지사항 하나 조회")
     @GetMapping("/admin/boards/{seq}")
     public AdminResBoard getBoard(
             @PathVariable("seq") Long seq
@@ -44,7 +44,7 @@ public class AdminBoardController {
         return AdminResBoard.of(adminBoardService.getBoard(seq));
     }
 
-    @ApiOperation("공지사항 생성")
+    @Operation(summary = "공지사항 생성")
     @PostMapping("/admin/boards")
     public ResponseEntity<Object> createBoard(
             @RequestParam("title") String title,
@@ -56,7 +56,7 @@ public class AdminBoardController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("공지사항 수정")
+    @Operation(summary = "공지사항 수정")
     @PutMapping("/admin/boards/{seq}")
     public ResponseEntity<Object> updateBoard(
             @PathVariable(value = "seq") Long seq,
@@ -69,7 +69,7 @@ public class AdminBoardController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("공지사항 삭제")
+    @Operation(summary = "공지사항 삭제")
     @DeleteMapping("/admin/boards/{seq}")
     public ResponseEntity<Object> deleteBoard(
             @PathVariable("seq") Long seq
@@ -79,7 +79,7 @@ public class AdminBoardController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("관리자 편지 리스트 조회")
+    @Operation(summary = "관리자 편지 리스트 조회")
     @GetMapping("/admin/postbox-message-admins")
     public List<AdminResPostboxMessageAdmin> getPostboxMessageAdminList(
             @RequestParam(value = "keyword", required = false) String keyword, //keyword is userSeq or content
@@ -92,7 +92,7 @@ public class AdminBoardController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("관리자 편지 하나 조회")
+    @Operation(summary = "관리자 편지 하나 조회")
     @GetMapping("/admin/postbox-message-admins/{seq}")
     public AdminResPostboxMessageAdmin getPostboxMessageAdmin(
             @PathVariable("seq") Long seq
@@ -100,7 +100,7 @@ public class AdminBoardController {
         return AdminResPostboxMessageAdmin.of(adminBoardService.getPostboxMessageAdmin(seq));
     }
 
-    @ApiOperation("관리자 편지 생성")
+    @Operation(summary = "관리자 편지 생성")
     @PostMapping("/admin/postbox-message-admins")
     public ResponseEntity<Object> createPostboxMessageAdmin(
             @RequestBody @Valid ReqAdminPostboxMessageAdminCreate req
@@ -110,7 +110,7 @@ public class AdminBoardController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("관리자 편지 수정")
+    @Operation(summary = "관리자 편지 수정")
     @PutMapping("/admin/postbox-message-admins/{seq}")
     public ResponseEntity<Object> updatePostboxMessageAdmin(
             @PathVariable(value = "seq") Long seq,
@@ -124,7 +124,7 @@ public class AdminBoardController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("관리자 편지 삭제")
+    @Operation(summary = "관리자 편지 삭제")
     @DeleteMapping("/admin/postbox-message-admins/{seq}")
     public ResponseEntity<Object> deletePostboxMessageAdmin(
             @PathVariable("seq") Long seq

--- a/src/main/java/com/mozi/moziserver/adminController/AdminChallengeController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminChallengeController.java
@@ -18,8 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Max;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/mozi/moziserver/adminController/AdminChallengeController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminChallengeController.java
@@ -11,7 +11,7 @@ import com.mozi.moziserver.model.entity.Challenge;
 import com.mozi.moziserver.model.entity.ChallengeStatistics;
 import com.mozi.moziserver.model.entity.ChallengeTheme;
 import com.mozi.moziserver.model.mappedenum.ChallengeTagType;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -31,7 +31,7 @@ public class AdminChallengeController {
     private final AdminChallengeService adminChallengeService;
 
     // -------------------- -------------------- Challenge -------------------- -------------------- //
-    @ApiOperation("챌린지 하나 조회")
+    @Operation(summary = "챌린지 하나 조회")
     @GetMapping("/admin/challenges/{seq}")
     public AdminResChallenge getChallenge(
             @PathVariable Long seq
@@ -46,7 +46,7 @@ public class AdminChallengeController {
         return AdminResChallenge.of(challenge, challengeTheme, challengeStatisticsList);
     }
 
-    @ApiOperation("챌린지 리스트 조회")
+    @Operation(summary = "챌린지 리스트 조회")
     @GetMapping("/admin/challenges")
     public List<AdminResChallengeList> getChallengeList(
             @RequestParam(name = "themeSeq", required = false) Long themeSeq,
@@ -64,7 +64,7 @@ public class AdminChallengeController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("챌린지 생성")
+    @Operation(summary = "챌린지 생성")
     @PostMapping("/admin/challenges")
     public ResponseEntity<Object> createChallenge(
             @Valid AdminReqChallengeCreate req
@@ -74,7 +74,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("챌린지 설명 추가")
+    @Operation(summary = "챌린지 설명 추가")
     @PostMapping("/admin/challenges/{seq}/explanations")
     public ResponseEntity<Object> createChallengeTest(
             @PathVariable Long seq,
@@ -86,7 +86,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("챌린지 수정")
+    @Operation(summary = "챌린지 수정")
     @PutMapping("/admin/challenges/{seq}")
     public ResponseEntity<Object> updateChallenge(
             @PathVariable Long seq,
@@ -105,7 +105,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("챌린지 삭제")
+    @Operation(summary = "챌린지 삭제")
     @DeleteMapping("/admin/challenges/{seq}")
     public ResponseEntity<Object> deleteChallenge(
             @PathVariable Long seq
@@ -117,7 +117,7 @@ public class AdminChallengeController {
 
     // -------------------- -------------------- Tag -------------------- -------------------- //
 
-    @ApiOperation("태그 리스트 조회")
+    @Operation(summary = "태그 리스트 조회")
     @GetMapping("/admin/tags")
     public List<AdminResTag> getTagList(
             @RequestParam(name = "keyword", required = false) String keyword
@@ -128,7 +128,7 @@ public class AdminChallengeController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("태그 등록")
+    @Operation(summary = "태그 등록")
     @PostMapping("/admin/tags")
     public ResponseEntity<Object> createTag(
             @RequestParam(name = "name") String name
@@ -138,7 +138,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("태그 수정")
+    @Operation(summary = "태그 수정")
     @PutMapping("/admin/tags/{seq}")
     public ResponseEntity<Object> updateTag(
             @PathVariable(name = "seq") Long seq,
@@ -150,7 +150,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("태그 삭제")
+    @Operation(summary = "태그 삭제")
     @DeleteMapping("/admin/tags/{seq}")
     public ResponseEntity<Object> updateTag(
             @PathVariable(name = "seq") Long seq
@@ -161,7 +161,7 @@ public class AdminChallengeController {
     }
 
     // -------------------- -------------------- ChallengeTheme -------------------- -------------------- //
-    @ApiOperation("테마 리스트 조회")
+    @Operation(summary = "테마 리스트 조회")
     @GetMapping("/admin/challege-themes")
     public List<ChallengeTheme> getChallengeThemeList(
             @RequestParam(name = "keyword", required = false) String keyword
@@ -169,7 +169,7 @@ public class AdminChallengeController {
         return adminChallengeService.getChallengeThemeList(keyword);
     }
 
-    @ApiOperation("테마 등록")
+    @Operation(summary = "테마 등록")
     @PostMapping("/admin/challege-themes")
     public ResponseEntity<Object> createChallengeTheme(
             @RequestParam(value = "name") String name,
@@ -181,7 +181,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("테마 수정")
+    @Operation(summary = "테마 수정")
     @PutMapping("/admin/challege-themes/{seq}")
     public ResponseEntity<Object> updateChallengeTheme(
             @PathVariable(name = "seq") Integer seq,
@@ -196,7 +196,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("테마 삭제")
+    @Operation(summary = "테마 삭제")
     @DeleteMapping("/admin/challege-themes/{seq}")
     public ResponseEntity<Object> deleteChallengeTheme(
             @PathVariable(name = "seq") Integer seq
@@ -207,7 +207,7 @@ public class AdminChallengeController {
     }
 
     // -------------------- -------------------- CurrentTagList -------------------- -------------------- //
-    @ApiOperation("현재 태그 리스트 조회")
+    @Operation(summary = "현재 태그 리스트 조회")
     @GetMapping("/admin/current-tag-lists")
     public List<AdminResCurrentTagList> getCurrentTagList(
     ) {
@@ -217,7 +217,7 @@ public class AdminChallengeController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("현재 태그 리스트 생성")
+    @Operation(summary = "현재 태그 리스트 생성")
     @PostMapping("/admin/current-tag-lists")
     public ResponseEntity<Object> createCurrentTagList(
             @RequestParam(name = "turn") Integer turn,
@@ -231,7 +231,7 @@ public class AdminChallengeController {
     }
 
     //모든 태그 리스트를 받아서 수정하기
-    @ApiOperation("현재 태그 리스트 수정")
+    @Operation(summary = "현재 태그 리스트 수정")
     @PutMapping("/admin/current-tag-lists")
     public ResponseEntity<Object> updateCurrentTagList(
             @RequestBody @Valid List<AdminReqCurrentTagList> req
@@ -244,7 +244,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("현재 태그 리스트 삭제")
+    @Operation(summary = "현재 태그 리스트 삭제")
     @DeleteMapping("/admin/current-tag-lists/{seq}")
     public ResponseEntity<Object> deleteCurrentTagList(
             @PathVariable(name = "seq") Long seq
@@ -255,7 +255,7 @@ public class AdminChallengeController {
     }
 
     // -------------------- -------------------- CurrentThemeList -------------------- -------------------- //
-    @ApiOperation("현재 테마 리스트 조회")
+    @Operation(summary = "현재 테마 리스트 조회")
     @GetMapping("/admin/current-theme-lists")
     public List<AdminResCurrentThemeList> getCurrentThemeList(
     ) {
@@ -265,7 +265,7 @@ public class AdminChallengeController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("현재 테마 리스트 생성")
+    @Operation(summary = "현재 테마 리스트 생성")
     @PostMapping("/admin/current-theme-lists")
     public ResponseEntity<Object> createCurrentThemeList(
             @RequestParam(name = "turn") Integer turn,
@@ -278,7 +278,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("현재 테마 리스트 수정")
+    @Operation(summary = "현재 테마 리스트 수정")
     @PutMapping("/admin/current-theme-lists")
     public ResponseEntity<Object> updateCurrentThemeList(
             @RequestBody @Valid List<AdminReqCurrentThemeList> req
@@ -293,7 +293,7 @@ public class AdminChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("현재 테마 리스트 삭제")
+    @Operation(summary = "현재 테마 리스트 삭제")
     @DeleteMapping("/admin/current-theme-lists/{seq}")
     public ResponseEntity<Object> deleteCurrentThemeList(
             @PathVariable(name = "seq") Long seq

--- a/src/main/java/com/mozi/moziserver/adminController/AdminConfirmController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminConfirmController.java
@@ -4,7 +4,7 @@ import com.mozi.moziserver.adminService.AdminConfirmService;
 import com.mozi.moziserver.httpException.ResponseError;
 import com.mozi.moziserver.model.adminRes.AdminResConfirmList;
 import com.mozi.moziserver.model.mappedenum.ConfirmStateType;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -23,7 +23,7 @@ public class AdminConfirmController {
 
     private final AdminConfirmService adminConfirmService;
 
-    @ApiOperation("인증 리스트 조회")
+    @Operation(summary = "인증 리스트 조회")
     @GetMapping("/admin/confirms")
     public List<AdminResConfirmList> getConfirmList(
             @RequestParam(name = "userSeq", required = false) Long userSeq,
@@ -36,7 +36,7 @@ public class AdminConfirmController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("인증 상태 변경 (BLOCKED or ACTIVE 상태로)")
+    @Operation(summary = "인증 상태 변경 (BLOCKED or ACTIVE 상태로)")
     @GetMapping("/admin/confirms/{seq}")
     public ResponseEntity<Object> updateConfirmState(
             @PathVariable("seq") Long seq,
@@ -51,7 +51,7 @@ public class AdminConfirmController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("인증 삭제")
+    @Operation(summary = "인증 삭제")
     @DeleteMapping("/admin/confirms/{seq}")
     public ResponseEntity<Object> deleteConfirm(
             @PathVariable("seq") Long seq

--- a/src/main/java/com/mozi/moziserver/adminController/AdminConfirmController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminConfirmController.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.constraints.Max;
+import jakarta.validation.constraints.Max;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/mozi/moziserver/adminController/AdminIslandController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminIslandController.java
@@ -6,7 +6,7 @@ import com.mozi.moziserver.httpException.ResponseError;
 import com.mozi.moziserver.model.adminRes.AdminResIsland;
 import com.mozi.moziserver.model.entity.DetailIsland;
 import com.mozi.moziserver.model.entity.Island;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -26,7 +26,7 @@ public class AdminIslandController {
     private final AdminIslandService adminIslandService;
 
     // -------------------- -------------------- Island -------------------- -------------------- //
-    @ApiOperation("섬 하나 조회")
+    @Operation(summary = "섬 하나 조회")
     @GetMapping(value = "/admin/islands/{seq}")
     public AdminResIsland getIsland(
             @PathVariable(value = "seq") Long seq
@@ -38,7 +38,7 @@ public class AdminIslandController {
         return AdminResIsland.of(island, detailIslandList);
     }
 
-    @ApiOperation("섬 모두 조회")
+    @Operation(summary = "섬 모두 조회")
     @GetMapping(value = "/admin/islands")
     public List<Island> getIslandList(
     ) {
@@ -46,7 +46,7 @@ public class AdminIslandController {
         return adminIslandService.getIslandList();
     }
 
-    @ApiOperation("섬 정보(Island) 생성")
+    @Operation(summary = "섬 정보(Island) 생성")
     @PostMapping(value = "/admin/islands")
     public ResponseEntity<Object> createIsland(
             @RequestParam(value = "name", required = true) String name,
@@ -59,7 +59,7 @@ public class AdminIslandController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("섬 정보(Island) 수정")
+    @Operation(summary = "섬 정보(Island) 수정")
     @PutMapping(value = "/admin/islands/{seq}")
     public ResponseEntity<Object> updateIsland(
             @PathVariable(value = "seq", required = true) Long seq,
@@ -75,7 +75,7 @@ public class AdminIslandController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("섬 삭제")
+    @Operation(summary = "섬 삭제")
     @DeleteMapping("/admin/islands/{seq}")
     public ResponseEntity<Object> deleteIsland(
             @PathVariable(value = "seq") Long seq
@@ -88,7 +88,7 @@ public class AdminIslandController {
 
     // -------------------- -------------------- DetailIsland -------------------- -------------------- //
 
-    @ApiOperation("이미지(DetailIsland) 생성")
+    @Operation(summary = "이미지(DetailIsland) 생성")
     @PostMapping(value = "/admin/detail-islands", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Object> createIsland(
             @RequestParam("islandSeq") Long islandSeq,
@@ -107,7 +107,7 @@ public class AdminIslandController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("섬 이미지(detailIsland) 수정")
+    @Operation(summary = "섬 이미지(detailIsland) 수정")
     @PutMapping(value = "/admin/detail-islands/{seq}")
     public ResponseEntity<Object> updateIslandImg(
             @PathVariable("seq") Long seq,
@@ -122,7 +122,7 @@ public class AdminIslandController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("섬 이미지(detailIsland) 삭제")
+    @Operation(summary = "섬 이미지(detailIsland) 삭제")
     @DeleteMapping("/admin/detail-islands/{seq}")
     public ResponseEntity<Object> deleteDetailIsland(
             @PathVariable(value = "seq") Long seq

--- a/src/main/java/com/mozi/moziserver/adminController/AdminQuestionController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminQuestionController.java
@@ -7,7 +7,7 @@ import com.mozi.moziserver.model.adminRes.AdminResSuggestionList;
 import com.mozi.moziserver.model.mappedenum.PriorityType;
 import com.mozi.moziserver.model.mappedenum.QuestionCategoryType;
 import com.mozi.moziserver.model.mappedenum.QuestionStateType;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -28,7 +28,7 @@ public class AdminQuestionController {
 
     private final AdminSuggestionService adminSuggestionService;
 
-    @ApiOperation("문의 리스트 조회")
+    @Operation(summary = "문의 리스트 조회")
     @GetMapping("/admin/questions")
     public List<AdminResQuestionList> getQuestionList(
             @RequestParam(name = "category", required = false) QuestionCategoryType category,
@@ -42,7 +42,7 @@ public class AdminQuestionController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("문의 (상태, 우선순위) 변경")
+    @Operation(summary = "문의 (상태, 우선순위) 변경")
     @PutMapping("/admin/questions/{seq}")
     public ResponseEntity<Object> updateQuestion(
             @PathVariable(value = "seq", required = true) Long seq,
@@ -54,7 +54,7 @@ public class AdminQuestionController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("문의 삭제")
+    @Operation(summary = "문의 삭제")
     @DeleteMapping("/admin/questions/{seq}")
     public ResponseEntity<Object> updateQuestion(
             @PathVariable(value = "seq", required = true) Long seq
@@ -64,7 +64,7 @@ public class AdminQuestionController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("챌린지 제안 리스트 조회")
+    @Operation(summary = "챌린지 제안 리스트 조회")
     @GetMapping("/admin/suggestions")
     public List<AdminResSuggestionList> getSuggestionList(
             @RequestParam(name = "pageNumber", required = false, defaultValue = "0") Integer pageNumber,
@@ -75,7 +75,7 @@ public class AdminQuestionController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("챌린지 제안 삭제")
+    @Operation(summary = "챌린지 제안 삭제")
     @DeleteMapping("/admin/suggestions/{seq}")
     public ResponseEntity<Object> deleteSuggestion(
             @PathVariable(value = "seq", required = true) Long seq

--- a/src/main/java/com/mozi/moziserver/adminController/AdminQuestionController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminQuestionController.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.constraints.Max;
+import jakarta.validation.constraints.Max;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/mozi/moziserver/adminController/AdminStickerController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminStickerController.java
@@ -4,8 +4,8 @@ import com.mozi.moziserver.adminService.AdminStickerService;
 import com.mozi.moziserver.httpException.ResponseError;
 import com.mozi.moziserver.security.SessionUser;
 import com.mozi.moziserver.service.StickerService;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -23,10 +23,10 @@ public class AdminStickerController {
 
     private final AdminStickerService adminStickerService;
 
-    @ApiOperation("스티커 생성")
+    @Operation(summary = "스티커 생성")
     @PostMapping("/admin/stickers")
     public ResponseEntity<Object> createSticker(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestPart MultipartFile image
     ) {
         if (image == null) {
@@ -38,10 +38,10 @@ public class AdminStickerController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("스티커 수정")
+    @Operation(summary = "스티커 수정")
     @PutMapping("/admin/stickers/{seq}")
     public ResponseEntity<Object> updateSticker(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable("seq") Long seq,
             @RequestPart MultipartFile image
     ) {

--- a/src/main/java/com/mozi/moziserver/adminController/AdminStickerController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminStickerController.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/mozi/moziserver/adminController/AdminUserController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminUserController.java
@@ -12,7 +12,7 @@ import com.mozi.moziserver.model.entity.UserIsland;
 import com.mozi.moziserver.model.entity.UserReward;
 import com.mozi.moziserver.model.mappedenum.PointReasonType;
 import com.mozi.moziserver.model.mappedenum.UserAuthType;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -33,7 +33,7 @@ public class AdminUserController {
     private final AdminUserRewardService adminUserRewardService;
 
     // -------------------- -------------------- UserPointRecord -------------------- -------------------- //
-    @ApiOperation("유저별 포인트 이력 조회")
+    @Operation(summary = "유저별 포인트 이력 조회")
     @GetMapping("/admin/users/{seq}/user-point-records")
     public List<AdminResUserPointRecordList> getUserPointRecordList(
             @PathVariable("seq") Long userSeq,
@@ -48,7 +48,7 @@ public class AdminUserController {
     }
 
     // -------------------- -------------------- ETC -------------------- -------------------- //
-    @ApiOperation("유저 리스트 조회")
+    @Operation(summary = "유저 리스트 조회")
     @GetMapping("/admin/users")
     public List<AdminResUserList> getUserList(
             @RequestParam(name = "keyword", required = false) String keyword, // keyword is userNickName or userEmail
@@ -75,7 +75,7 @@ public class AdminUserController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("유저 보상(포인트/섬) 조회")
+    @Operation(summary = "유저 보상(포인트/섬) 조회")
     @GetMapping("/admin/user-rewards")
     public List<AdminResUserRewardList> getUserRewardList(
             @RequestParam(name = "keyword", required = false) String keyword, // keyword is userSeq or userNickname

--- a/src/main/java/com/mozi/moziserver/adminController/AdminUserController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminUserController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.constraints.Max;
+import jakarta.validation.constraints.Max;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/mozi/moziserver/common/Constant.java
+++ b/src/main/java/com/mozi/moziserver/common/Constant.java
@@ -22,6 +22,8 @@ public interface Constant {
 
     String CURRENT_PW_FIELD_NAME = "currentPw";
 
+    Long TEST_USER_SEQ = 1L;
+
     //TODO fix
     String ID_REGEX = "[A-Za-z0-9]{5,}$";
 

--- a/src/main/java/com/mozi/moziserver/config/AppConfig.java
+++ b/src/main/java/com/mozi/moziserver/config/AppConfig.java
@@ -19,7 +19,7 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.List;

--- a/src/main/java/com/mozi/moziserver/config/SecurityConfig.java
+++ b/src/main/java/com/mozi/moziserver/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
         final String activeProfiles = String.join(",", env.getActiveProfiles());
 
         http
-
+                .authenticationManager(authManager(http))
                 .csrf(AbstractHttpConfigurer::disable)
                 .headers((headerConfig) ->
                         headerConfig.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable

--- a/src/main/java/com/mozi/moziserver/config/SecurityConfig.java
+++ b/src/main/java/com/mozi/moziserver/config/SecurityConfig.java
@@ -5,9 +5,7 @@ import com.mozi.moziserver.common.Constant;
 import com.mozi.moziserver.log.ApiLogFilter;
 import com.mozi.moziserver.repository.RememberMeTokenRepository;
 import com.mozi.moziserver.security.*;
-import com.mozi.moziserver.security.UserEmailSignInService;
-import com.mozi.moziserver.security.RememberMeService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -15,84 +13,82 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 
 @Configuration
 @EnableWebSecurity
-@SuppressWarnings("unused")
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+@RequiredArgsConstructor
+//@SuppressWarnings("unused")
+public class SecurityConfig {
 
-    @Autowired
-    UserSocialAuthenticationProvider userSocialAuthenticationProvider;
+    private final UserSocialAuthenticationProvider userSocialAuthenticationProvider;
 
-    @Autowired
-    private RememberMeTokenRepository rememberMeTokenRepository;
+    private final RememberMeTokenRepository rememberMeTokenRepository;
 
-    @Autowired
-    private UserEmailSignInService userEmailSignInService;
+    private final UserEmailSignInService userEmailSignInService;
 
-    @Autowired
-    private RememberMeService rememberMeService;
+    private final RememberMeService rememberMeService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-    @Autowired
-    private Environment env;
+    private final Environment env;
 
+    @Bean
+    public AuthenticationManager authManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder =
+                http.getSharedObject(AuthenticationManagerBuilder.class);
 
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth
-                .userDetailsService(userEmailSignInService)
-                .and()
-                .authenticationProvider(userSocialAuthenticationProvider)
-                .authenticationProvider(new UserRememberAuthenticationProvider());
-    }
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        final String activeProfiles = String.join(",", env.getActiveProfiles());
-
-        http
-                .cors()
-                .and()
-                .csrf().disable()
-                .headers().frameOptions().disable()
-                .and()
-                .addFilterBefore(new ApiLogFilter(activeProfiles, objectMapper), UsernamePasswordAuthenticationFilter.class)
-                .authorizeRequests()
-                .antMatchers(Constant.PERMIT_ALL_PATHS).permitAll()
-                .antMatchers(Constant.AUTHENTICATED_PATHS).authenticated()
-                .antMatchers(Constant.ROLE_ADMIN_PATHS).hasRole(Constant.ROLE_ADMIN)
-                .antMatchers(Constant.ROLE_USER_PATHS).hasRole(Constant.ROLE_USER)
-                .anyRequest().permitAll()
-                .and()
-                .formLogin().disable()
-                .httpBasic().disable()
-                .exceptionHandling()
-                .authenticationEntryPoint(new DefaultAuthenticationEntryPoint())
-                .accessDeniedHandler(new DefaultAccessDeniedHandler())
-                .and()
-                .rememberMe(configurer -> configurer
-                        .alwaysRemember(true)
-                        .rememberMeServices(rememberMeService))
-                .logout()
-                .logoutUrl("/api/v1/users/signout")
-                .logoutSuccessHandler((request, response, authentication) -> {
-                    response.setStatus(HttpServletResponse.SC_OK);
-                })
-                .deleteCookies("JSESSIONID",  "remember-me");
+        authenticationManagerBuilder.userDetailsService(userEmailSignInService);
+        authenticationManagerBuilder.authenticationProvider(userSocialAuthenticationProvider);
+        authenticationManagerBuilder.authenticationProvider(new UserRememberAuthenticationProvider());
+        return authenticationManagerBuilder.build();
     }
 
     @Bean
-    @Override
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        return super.authenticationManagerBean();
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception { // 3
+        final String activeProfiles = String.join(",", env.getActiveProfiles());
+
+        http
+
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers((headerConfig) ->
+                        headerConfig.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable
+                        )
+                )
+                .addFilterBefore(new ApiLogFilter(activeProfiles, objectMapper), UsernamePasswordAuthenticationFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling((exceptionHandling) ->
+                        exceptionHandling.authenticationEntryPoint(new DefaultAuthenticationEntryPoint())
+                                .accessDeniedHandler(new DefaultAccessDeniedHandler())
+                )
+                .authorizeHttpRequests((authorize) ->
+                        authorize
+                                .requestMatchers(Constant.PERMIT_ALL_PATHS).permitAll()
+                                .requestMatchers(Constant.AUTHENTICATED_PATHS).authenticated()
+                                .requestMatchers(Constant.ROLE_ADMIN_PATHS).hasRole(Constant.ROLE_ADMIN)
+                                .requestMatchers(Constant.ROLE_USER_PATHS).hasRole(Constant.ROLE_USER)
+                                .anyRequest().permitAll()
+                )
+                .rememberMe((rememberMe) ->
+                        rememberMe
+                                .alwaysRemember(true)
+                                .rememberMeServices(rememberMeService)
+                )
+                .logout((logout) ->
+                        logout
+                                .logoutUrl("/api/v1/users/signout")
+                                .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler())
+                                .deleteCookies("JSESSIONID", "remember-me")
+                );
+
+        return http.build();
     }
 
     @Bean

--- a/src/main/java/com/mozi/moziserver/config/SwaggerConfig.java
+++ b/src/main/java/com/mozi/moziserver/config/SwaggerConfig.java
@@ -1,39 +1,37 @@
 package com.mozi.moziserver.config;
 
-import com.mozi.moziserver.MoziServerApplication;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
 
-import javax.servlet.http.HttpSession;
-import java.util.Locale;
 
 @Configuration
-//@Profile({"default", "dev"})
 public class SwaggerConfig {
-    // path : /swagger-ui/index.html
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .ignoredParameterTypes(Locale.class, HttpSession.class)
-                .useDefaultResponseMessages(false)
-                .select()
-                .apis(RequestHandlerSelectors.basePackage(MoziServerApplication.class.getPackageName()))
-                .build()
-                .apiInfo(apiInfo());
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("MoziServer Swagger:)")
+                        .description("REST API")
+                        .version("0.0.1"));
     }
 
-    private ApiInfo apiInfo() {
-        return new ApiInfoBuilder()
-                .title("MoziServer Swagger:)")
-                .description("REST API")
-                .version("0.0.1")
+    @Bean
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder()
+                .group("user")
+                .pathsToMatch("/api/v1/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi adminApi() {
+        return GroupedOpenApi.builder()
+                .group("admin")
+                .pathsToMatch("/api/admin/**")
                 .build();
     }
 }

--- a/src/main/java/com/mozi/moziserver/controller/ChallengeController.java
+++ b/src/main/java/com/mozi/moziserver/controller/ChallengeController.java
@@ -11,8 +11,8 @@ import com.mozi.moziserver.model.res.ResSearchOfChallengeList;
 import com.mozi.moziserver.repository.UserRepository;
 import com.mozi.moziserver.security.SessionUser;
 import com.mozi.moziserver.service.*;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,10 +39,10 @@ public class ChallengeController {
     private final ConfirmService confirmService;
     private final UserService userService;
 
-    @ApiOperation("챌린지 하나 조회")
+    @Operation(summary = "챌린지 하나 조회")
     @GetMapping("/v1/challenges/{seq}")
     public ResChallenge getChallenge(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long seq
     ) {
 
@@ -67,10 +67,10 @@ public class ChallengeController {
         return ResChallenge.of(challenge, optionalUserChallenge, optionalUserChallengeRecord, challengeStatisticsList, challengeTagList, challengeScrap,optionalConfirm);
     }
 
-    @ApiOperation("챌린지 모두 조회")
+    @Operation(summary = "챌린지 모두 조회")
     @GetMapping("/v1/challenges")
     public ResSearchOfChallengeList getChallengeList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqChallengeList req
     ) {
 
@@ -110,10 +110,10 @@ public class ChallengeController {
         return ResSearchOfChallengeList.of(challengeCnt,challengeLists);
     }
 
-    @ApiOperation("스크랩한 챌린지 리스트 조회")
+    @Operation(summary = "스크랩한 챌린지 리스트 조회")
     @GetMapping("v1/challenges/scrap")
     public List<ResChallengeList> getScrappedChallengeList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqList req
     ) {
 
@@ -126,10 +126,10 @@ public class ChallengeController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("챌린지 스크랩 생성")
+    @Operation(summary = "챌린지 스크랩 생성")
     @PostMapping("/v1/challenges/{seq}/scraps")
     public ResponseEntity<Object> createChallengeScrap(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long seq
     ) {
 
@@ -139,10 +139,10 @@ public class ChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("챌린지 스크랩 취소")
+    @Operation(summary = "챌린지 스크랩 취소")
     @DeleteMapping("/v1/challenges/{seq}/scraps")
     public ResponseEntity<Object> deleteChallengeScrap(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long seq
     ) {
 

--- a/src/main/java/com/mozi/moziserver/controller/ChallengeController.java
+++ b/src/main/java/com/mozi/moziserver/controller/ChallengeController.java
@@ -19,7 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/com/mozi/moziserver/controller/ConfigurationController.java
+++ b/src/main/java/com/mozi/moziserver/controller/ConfigurationController.java
@@ -17,10 +17,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.servlet.http.HttpSession;
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/com/mozi/moziserver/controller/ConfigurationController.java
+++ b/src/main/java/com/mozi/moziserver/controller/ConfigurationController.java
@@ -8,8 +8,8 @@ import com.mozi.moziserver.model.req.*;
 import com.mozi.moziserver.model.res.ResUserInfo;
 import com.mozi.moziserver.security.SessionUser;
 import com.mozi.moziserver.service.*;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -36,10 +36,10 @@ public class ConfigurationController {
     private final UserService userService;
 
     // -------------------- -------------------- Question -------------------- -------------------- //
-    @ApiOperation("문의 등록")
+    @Operation(summary = "문의 등록")
     @PostMapping("/v1/questions")
     public ResponseEntity<Object> createQuestion(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestParam(name = "email", required = true) String email,
             @RequestParam(name = "title", required = true) String title,
             @RequestParam(name = "content", required = true) String content,
@@ -62,10 +62,10 @@ public class ConfigurationController {
     }
 
     // -------------------- -------------------- Board -------------------- -------------------- //
-    @ApiOperation("공지사항 보기")
+    @Operation(summary = "공지사항 보기")
     @GetMapping("/v1/boards")
     public List<Board> getBoardListByCreatedAt(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqList req
     ) {
 
@@ -73,10 +73,10 @@ public class ConfigurationController {
         return boardService.getAllBoardListByCreatedAt(user, req);
     }
 
-    @ApiOperation("공지사항 확인 완료")
+    @Operation(summary = "공지사항 확인 완료")
     @PutMapping("/v1/boards/{seq}/checked")
     public ResponseEntity<Object> checkedBoard(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable("seq") Long seq
     ) {
 
@@ -87,10 +87,10 @@ public class ConfigurationController {
     }
 
     // -------------------- -------------------- Suggestion -------------------- -------------------- //
-    @ApiOperation("챌린지 제안하기")
+    @Operation(summary = "챌린지 제안하기")
     @PostMapping("/v1/suggestions")
     public ResponseEntity<Object> createSuggestion(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestBody @Valid ReqSuggestionCreate req
     ) {
 
@@ -101,10 +101,10 @@ public class ConfigurationController {
     }
 
     // -------------------- -------------------- User -------------------- -------------------- //
-    @ApiOperation("내 정보 조회")
+    @Operation(summary = "내 정보 조회")
     @GetMapping("/v1/users/me")
     public ResUserInfo getUserInfo(
-            @ApiParam(hidden = true) @SessionUser Long userSeq
+            @Parameter(hidden = true) @SessionUser Long userSeq
     ) {
 
         User user = userService.getUserBySeq(userSeq);
@@ -112,10 +112,10 @@ public class ConfigurationController {
         return ResUserInfo.of(user);
     }
 
-    @ApiOperation("닉네임 등록 및 수정")
+    @Operation(summary = "닉네임 등록 및 수정")
     @PostMapping("/v1/users/me/nickname/{nickName}")
     public ResponseEntity<Object> updateUserNickName(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable String nickName
     ) {
 
@@ -125,20 +125,20 @@ public class ConfigurationController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("튜토리얼 확인 완료")
+    @Operation(summary = "튜토리얼 확인 완료")
     @PutMapping("/v1/users/me/tutorial/checked")
     public ResponseEntity<Object> checkedTutorial(
-            @ApiParam(hidden = true) @SessionUser Long userSeq
+            @Parameter(hidden = true) @SessionUser Long userSeq
     ) {
         userService.checkTutorial(userSeq);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("비밀번호 확인")
+    @Operation(summary = "비밀번호 확인")
     @PostMapping("/v1/users/me/password/check")
     public ResponseEntity<Object> checkPassword(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestBody @Valid ReqUserPw req
     ) {
 
@@ -151,10 +151,10 @@ public class ConfigurationController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("비밀번호 재설정 (이메일 인증 X)")
+    @Operation(summary = "비밀번호 재설정 (이메일 인증 X)")
     @PutMapping("/v1/users/me/password")
     public ResponseEntity<Object> updateUserPassword(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestBody @Valid ReqUserPw req
             ) {
         User user = userService.getUserBySeq(userSeq);
@@ -163,10 +163,10 @@ public class ConfigurationController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("이메일 변경 (이메일 인증 필수)")
+    @Operation(summary = "이메일 변경 (이메일 인증 필수)")
     @PutMapping(value = "/v1/users/me/email/{email}")
     public ResponseEntity<Object> authUserEmail(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable @Valid String email
     ) {
         User user = userService.getUserBySeq(userSeq);
@@ -176,10 +176,10 @@ public class ConfigurationController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("탈퇴하기")
+    @Operation(summary = "탈퇴하기")
     @PostMapping(value = "v1/users/resign")
     public ResponseEntity<Object> resign(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestBody @Valid ReqResign reqResign,
             HttpSession session
     ) {

--- a/src/main/java/com/mozi/moziserver/controller/ConfirmController.java
+++ b/src/main/java/com/mozi/moziserver/controller/ConfirmController.java
@@ -13,8 +13,8 @@ import com.mozi.moziserver.model.res.ResWeekConfirm;
 import com.mozi.moziserver.security.SessionUser;
 import com.mozi.moziserver.service.ConfirmService;
 import com.mozi.moziserver.service.UserService;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -36,10 +36,10 @@ public class ConfirmController {
     private final ConfirmService confirmService;
     private final UserService userService;
 
-    @ApiOperation("스토리 리스트 조회")
+    @Operation(summary = "스토리 리스트 조회")
     @GetMapping("/v1/challenges/confirms")
     public List<ResConfirmList> getConfirmList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestParam(required = false) Optional<ConfirmListType> confirmListType,
             @Valid ReqList req
     )
@@ -56,10 +56,10 @@ public class ConfirmController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("챌린지별 스토리 전체 조회")
+    @Operation(summary = "챌린지별 스토리 전체 조회")
     @GetMapping("/v1/challenges/{challengeSeq}/confirms")
     public List<ResConfirmList> getConfirmListByChallenge(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long challengeSeq,
             @Valid ReqList req
     ) {
@@ -72,10 +72,10 @@ public class ConfirmController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("유저 챌린지별 스토리 전체 조회")
+    @Operation(summary = "유저 챌린지별 스토리 전체 조회")
     @GetMapping("/v1/user-challenges/{userChallengeSeq}/confirms")
     public List<ResConfirmList> getConfirmListNyUserChallenge(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long userChallengeSeq
     ) {
 
@@ -87,10 +87,10 @@ public class ConfirmController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("본인 스토리 전체 조회")
+    @Operation(summary = "본인 스토리 전체 조회")
     @GetMapping("/v1/users/me/confirms")
     public List<ResConfirmList> getUserConfirmList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqList req
     ) {
 
@@ -102,10 +102,10 @@ public class ConfirmController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("제로리 주민들의 활동보기")
+    @Operation(summary = "제로리 주민들의 활동보기")
     @GetMapping("/v1/confirms/week")
     public ResWeekConfirm getWeekConfirm(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestParam(required = false) Optional<ConfirmListType> confirmListType
 
     ) {
@@ -117,10 +117,10 @@ public class ConfirmController {
         return confirmService.getWeekConfirm(confirmListType.get());
     }
 
-    @ApiOperation("챌린지별 상세 스토리")
+    @Operation(summary = "챌린지별 상세 스토리")
     @GetMapping("/v1/users/me/challenges/confirms")
     public List<ResConfirmList> getConfirmOfUser(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqConfirmOfUser reqConfirmOfUser
     ) {
 
@@ -132,10 +132,10 @@ public class ConfirmController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("스토리 생성")
+    @Operation(summary = "스토리 생성")
     @PostMapping("/v1/challenges/{challengeSeq}/confirms")
     public ResponseEntity<Object> createConfirm(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long challengeSeq,
             @RequestPart MultipartFile image
     ) {
@@ -151,10 +151,10 @@ public class ConfirmController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("스토리 좋아요")
+    @Operation(summary = "스토리 좋아요")
     @PostMapping("/v1/confirms/{seq}/like")
     public ResponseEntity<Object> createConfirmLike(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long seq
     ) {
 
@@ -164,10 +164,10 @@ public class ConfirmController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("스토리 좋아요 취소")
+    @Operation(summary = "스토리 좋아요 취소")
     @DeleteMapping ("/v1/confirms/{seq}/like")
     public ResponseEntity<Object> deleteConfirmLike(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long seq
     ) {
 
@@ -177,10 +177,10 @@ public class ConfirmController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("신고 생성")
+    @Operation(summary = "신고 생성")
     @PostMapping("/v1/confirms/{confirmSeq}/declarations")
     public ResponseEntity<Object> createDeclaration(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long confirmSeq,
             @RequestBody @Valid ReqDeclarationCreate req
     ) {
@@ -190,10 +190,10 @@ public class ConfirmController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("스토리 삭제")
+    @Operation(summary = "스토리 삭제")
     @DeleteMapping("/v1/confirms/{seq}")
     public ResponseEntity<Object> deleteConfirm(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable Long seq
     ) {
 
@@ -204,10 +204,10 @@ public class ConfirmController {
     }
 
     // -------------------- -------------------- ConfirmSticker -------------------- -------------------- //
-    @ApiOperation("스티커 전체 조회")
+    @Operation(summary = "스티커 전체 조회")
     @GetMapping("/v1/stickers")
     public List<ResStickerList> getStickerList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq
+            @Parameter(hidden = true) @SessionUser Long userSeq
     ) {
         return confirmService.getSticker()
                 .stream()
@@ -215,10 +215,10 @@ public class ConfirmController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("스티커 생성(부착)")
+    @Operation(summary = "스티커 생성(부착)")
     @PostMapping("/v1/confirms/{seq}/confirm-stickers")
     public ResponseEntity<Object> createConfirmSticker(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestBody @Valid ReqConfirmSticker reqConfirmSticker,
             @PathVariable Long seq
     ) {

--- a/src/main/java/com/mozi/moziserver/controller/ConfirmController.java
+++ b/src/main/java/com/mozi/moziserver/controller/ConfirmController.java
@@ -22,7 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/com/mozi/moziserver/controller/ConstantController.java
+++ b/src/main/java/com/mozi/moziserver/controller/ConstantController.java
@@ -5,7 +5,7 @@ import com.mozi.moziserver.model.entity.ChallengeTheme;
 import com.mozi.moziserver.model.res.ResCurrentTagList;
 import com.mozi.moziserver.service.ChallengeService;
 import com.mozi.moziserver.service.CurrentTagListService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,7 +24,7 @@ public class ConstantController {
     private final CurrentTagListService currentTagListService;
     private final ChallengeService challengeService;
 
-    @ApiOperation("태그 리스트 조회")
+    @Operation(summary = "태그 리스트 조회")
     @GetMapping("/v1/tags")
     public List<ResCurrentTagList> getCurrentTagList() {
 
@@ -34,7 +34,7 @@ public class ConstantController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("챌린지 테마 리스트 조회")
+    @Operation(summary = "챌린지 테마 리스트 조회")
     @GetMapping("/v1/challenge-themes")
     public List<ChallengeTheme> getChallengeThemeList() {
 

--- a/src/main/java/com/mozi/moziserver/controller/EmailAuthController.java
+++ b/src/main/java/com/mozi/moziserver/controller/EmailAuthController.java
@@ -2,7 +2,8 @@ package com.mozi.moziserver.controller;
 
 import com.mozi.moziserver.model.entity.EmailAuth;
 import com.mozi.moziserver.service.EmailAuthService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -11,11 +12,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 import java.net.URI;
 
-@ApiIgnore
+@Hidden
 @RestController
 @RequestMapping("/email/auth")
 @RequiredArgsConstructor
@@ -23,7 +23,7 @@ public class EmailAuthController {
 
     private final EmailAuthService emailAuthService;
 
-    @ApiOperation(value = "", hidden = true)
+    @Operation(summary = "", hidden = true)
     @GetMapping("/{token}")
     public ResponseEntity<Object> authEmail(@PathVariable String token) throws Exception {
         HttpHeaders httpHeaders = new HttpHeaders();

--- a/src/main/java/com/mozi/moziserver/controller/HealthCheckController.java
+++ b/src/main/java/com/mozi/moziserver/controller/HealthCheckController.java
@@ -1,6 +1,6 @@
 package com.mozi.moziserver.controller;
 
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class HealthCheckController {
 
-    @ApiOperation("API 확인 용도")
+    @Operation(summary = "API 확인 용도")
     @GetMapping("/health-check")
     public ResponseEntity<Object> getHealthCheck(
     ) {

--- a/src/main/java/com/mozi/moziserver/controller/PostboxMessageController.java
+++ b/src/main/java/com/mozi/moziserver/controller/PostboxMessageController.java
@@ -17,7 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/mozi/moziserver/controller/PostboxMessageController.java
+++ b/src/main/java/com/mozi/moziserver/controller/PostboxMessageController.java
@@ -9,8 +9,8 @@ import com.mozi.moziserver.model.req.ReqList;
 import com.mozi.moziserver.model.res.*;
 import com.mozi.moziserver.security.SessionUser;
 import com.mozi.moziserver.service.*;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -35,10 +35,10 @@ public class PostboxMessageController {
 
     // -------------------- -------------------- PostboxMessageAnimal -------------------- -------------------- //
     // TODO ERASE (NOT USED V2)
-    @ApiOperation("동물의 편지 하나 조회")
+    @Operation(summary = "동물의 편지 하나 조회")
     @GetMapping("/v1/postbox-message-animals/{seq}")
     public ResPostboxMessageAnimal getPostboxMessageAnimalV1(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable("seq") Long seq
 
     ) {
@@ -50,10 +50,10 @@ public class PostboxMessageController {
         return ResPostboxMessageAnimal.of(postboxMessageAnimal, preparationItemList);
     }
 
-    @ApiOperation("동물의 편지 리스트 조회")
+    @Operation(summary = "동물의 편지 리스트 조회")
     @GetMapping("/v1/postbox-message-animals")
     public List<ResPostboxMessageAnimalList> getPostboxMessageAnimalList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqList req
     ) {
 
@@ -64,10 +64,10 @@ public class PostboxMessageController {
     }
 
     // -------------------- -------------------- PostboxMessageAdmin -------------------- -------------------- //
-    @ApiOperation("관리자의 편지 리스트 조회")
+    @Operation(summary = "관리자의 편지 리스트 조회")
     @GetMapping("/v1/postbox-message-admins")
     public List<ResPostboxMessageAdminList> getPostboxMessageAdminList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqList req
     ) {
 
@@ -78,10 +78,10 @@ public class PostboxMessageController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("관리자 편지 확인 완료")
+    @Operation(summary = "관리자 편지 확인 완료")
     @PutMapping("/v1/postbox-message-admins/{seq}/checked")
     public ResponseEntity<Object> checkUserChallenge(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable("seq") Long seq
     ) {
 
@@ -91,10 +91,10 @@ public class PostboxMessageController {
     }
 
     // -------------------- -------------------- Animal -------------------- -------------------- //
-    @ApiOperation("동물 하나 조회")
+    @Operation(summary = "동물 하나 조회")
     @GetMapping("/v1/animals/{seq}")
     public ResAnimal getAnimal(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable("seq") Long seq
     ) {
 
@@ -102,10 +102,10 @@ public class PostboxMessageController {
     }
 
     // -------------------- -------------------- UserNotice -------------------- -------------------- //
-    @ApiOperation("유저 알림 조회")
+    @Operation(summary = "유저 알림 조회")
     @GetMapping("/v1/user-notices/{type}")
     public ResUserNotice getUserNotice(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable UserNoticeType type
     ) {
 
@@ -114,10 +114,10 @@ public class PostboxMessageController {
         return ResUserNotice.of(userNotice);
     }
 
-    @ApiOperation("유저 알림 확인")
+    @Operation(summary = "유저 알림 확인")
     @PutMapping("/v1/user-notices/{type}/checked")
     public ResponseEntity<Object> checkUserNotice(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable UserNoticeType type
     ) {
 
@@ -127,10 +127,10 @@ public class PostboxMessageController {
     }
 
     // -------------------- v2 -------------------- //
-    @ApiOperation("동물의 편지 하나 조회")
+    @Operation(summary = "동물의 편지 하나 조회")
     @GetMapping("/v2/postbox-message-animals/{seq}")
     public ResPostboxMessageAnimal getPostboxMessageAnimal(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable("seq") Long seq
 
     ) {

--- a/src/main/java/com/mozi/moziserver/controller/TestController.java
+++ b/src/main/java/com/mozi/moziserver/controller/TestController.java
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @Profile("!production")
 @Slf4j

--- a/src/main/java/com/mozi/moziserver/controller/TestController.java
+++ b/src/main/java/com/mozi/moziserver/controller/TestController.java
@@ -4,8 +4,8 @@ import com.mozi.moziserver.model.req.ReqTestUserChallengeStartDateUpdate;
 import com.mozi.moziserver.security.SessionUser;
 import com.mozi.moziserver.service.BadWordService;
 import com.mozi.moziserver.service.UserChallengeService;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
@@ -25,10 +25,10 @@ public class TestController {
     private final UserChallengeService userChallengeService;
     private final BadWordService badWordService;
 
-    @ApiOperation("유저 챌린지 startDate 변경")
+    @Operation(summary = "유저 챌린지 startDate 변경")
     @PutMapping("/user-challenges/{seq}")
     public ResponseEntity<Object> updateUserChallengeStartDate(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable("seq") Long userChallengeSeq,
             @RequestBody @Valid ReqTestUserChallengeStartDateUpdate req
     ) {
@@ -38,10 +38,10 @@ public class TestController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("비속어 생성")
+    @Operation(summary = "비속어 생성")
     @PostMapping("/admin/badwords")
     public ResponseEntity<Object> createBadWord(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestParam String content
     ) {
 

--- a/src/main/java/com/mozi/moziserver/controller/UserChallengeController.java
+++ b/src/main/java/com/mozi/moziserver/controller/UserChallengeController.java
@@ -12,8 +12,8 @@ import com.mozi.moziserver.model.res.ResUserChallengeOfReward;
 import com.mozi.moziserver.security.SessionUser;
 import com.mozi.moziserver.service.UserChallengeService;
 import com.mozi.moziserver.service.UserService;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -33,10 +33,10 @@ public class UserChallengeController {
     private final UserChallengeService userChallengeService;
     private final UserService userService;
 
-    @ApiOperation("유저 챌린지 날짜별 리스트 조회")
+    @Operation(summary = "유저 챌린지 날짜별 리스트 조회")
     @GetMapping("/v1/period/user-challenges")
     public List<ResUserChallengeList> getUserChallengeList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqUserChallengeList req
     ) {
         if (req.getStartDate().isAfter(req.getEndDate())) {
@@ -49,10 +49,10 @@ public class UserChallengeController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("유저 챌린지 전체 조회")
+    @Operation(summary = "유저 챌린지 전체 조회")
     @GetMapping("/v1/user-challenges")
     public List<ResUserChallengeList> getUserChallengeList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqList req
     ) {
         return userChallengeService.getUserChallengeList(userSeq, req)
@@ -61,10 +61,10 @@ public class UserChallengeController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("완료한 유저 챌린지 리스트 조회 (유저가 확인 안한 것만)")
+    @Operation(summary = "완료한 유저 챌린지 리스트 조회 (유저가 확인 안한 것만)")
     @GetMapping("/v1/user-challenges/end")
     public List<ResUserChallengeOfReward> getEndUserChallengeList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq
+            @Parameter(hidden = true) @SessionUser Long userSeq
     ) {
         return userChallengeService.getEndUserChallengeList(userSeq)
                 .stream()
@@ -72,10 +72,10 @@ public class UserChallengeController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("인증한 제로 활동-활동별 (마이페이지)")
+    @Operation(summary = "인증한 제로 활동-활동별 (마이페이지)")
     @GetMapping("/v1/user-challenges/confirmed")
     public List<ResConfirmedUserChallengeRecord> getUserChallengeRecordList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqList req
     ) {
         return userChallengeService.getUserChallengeRecordListByUserSeq(userSeq, req)
@@ -84,10 +84,10 @@ public class UserChallengeController {
                 .collect(Collectors.toList());
     }
 
-    @ApiOperation("유저 챌린지 생성")
+    @Operation(summary = "유저 챌린지 생성")
     @PostMapping("/v1/user-challenges")
     public ResponseEntity<Object> createUserChallenge(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestBody @Valid ReqUserChallengeCreate req
     ) {
 
@@ -97,10 +97,10 @@ public class UserChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("완료한 유저 챌린지 확인 완료")
+    @Operation(summary = "완료한 유저 챌린지 확인 완료")
     @PutMapping("/v1/user-challenges/{seq}/checked")
     public ResponseEntity<Object> checkedUserChallenge(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable("seq") Long userChallengeSeq
     ) {
         userChallengeService.checkUserChallenge(userSeq, userChallengeSeq);
@@ -108,10 +108,10 @@ public class UserChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("유저 챌린지 그만두기")
+    @Operation(summary = "유저 챌린지 그만두기")
     @PutMapping("/v1/user-challenges/{seq}/stop")
     public ResponseEntity<Object> stopUserChallenge(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @PathVariable("seq") Long userChallengeSeq
     ) {
         userChallengeService.stopUserChallenge(userSeq, userChallengeSeq);
@@ -119,10 +119,10 @@ public class UserChallengeController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("유저 챌린지 생성 가능한지 확인")
+    @Operation(summary = "유저 챌린지 생성 가능한지 확인")
     @GetMapping("/v1/user-challenges/creatable")
     public ResponseEntity<Object> checkCreatableUserChallenge(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @Valid ReqChallengeAndDate req
     ) {
 

--- a/src/main/java/com/mozi/moziserver/controller/UserChallengeController.java
+++ b/src/main/java/com/mozi/moziserver/controller/UserChallengeController.java
@@ -20,7 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/mozi/moziserver/controller/UserController.java
+++ b/src/main/java/com/mozi/moziserver/controller/UserController.java
@@ -13,8 +13,8 @@ import com.mozi.moziserver.security.SessionUser;
 import com.mozi.moziserver.service.EmailAuthService;
 import com.mozi.moziserver.service.UserRewardService;
 import com.mozi.moziserver.service.UserService;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -42,7 +42,7 @@ public class UserController {
     private final EmailAuthService emailAuthService;
     private final UserRewardService userRewardService;
 
-    @ApiOperation("가입 (ID)")
+    @Operation(summary = "가입 (ID)")
     @PostMapping(value = "/v1/users/signup", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Object> signUpUser(
             @RequestBody @Valid ReqUserSignUp reqUserSignUp
@@ -53,7 +53,7 @@ public class UserController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("로그인 (ID, 소셜)")
+    @Operation(summary = "로그인 (ID, 소셜)")
     @PostMapping(value = "/v1/users/signin", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Object> signInUser(
             @RequestBody @Valid ReqUserSignIn req,
@@ -77,14 +77,14 @@ public class UserController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("로그아웃")
+    @Operation(summary = "로그아웃")
     @PostMapping("/v1/users/signout")
     public ResponseEntity<Object> signOut() {
 
         throw new IllegalStateException("This Method not working");
     }
 
-    @ApiOperation("닉네임 중복 확인")
+    @Operation(summary = "닉네임 중복 확인")
     @GetMapping("/v1/users/nicknames/{nickName}/check")
     public ResponseEntity<Object> checkNickNameDuplicate(
             @PathVariable String nickName
@@ -95,7 +95,7 @@ public class UserController {
         );
     }
 
-    @ApiOperation("이메일 찾기")
+    @Operation(summary = "이메일 찾기")
     @GetMapping("/v1/find/emails")
     public ResEmail findUserAuthEmail(
             @Valid ReqUserNickNameAndPw req
@@ -110,7 +110,7 @@ public class UserController {
         return ResEmail.of(userAuth);
     }
 
-    @ApiOperation("이메일 중복 확인")
+    @Operation(summary = "이메일 중복 확인")
     @GetMapping("/v1/users/emails/{email}/check")
     public ResponseEntity<Object> checkEmailDuplicate(
             @PathVariable String email
@@ -121,7 +121,7 @@ public class UserController {
         );
     }
 
-    @ApiOperation("비밀번호 재설정 (이메일 인증 필수)")
+    @Operation(summary = "비밀번호 재설정 (이메일 인증 필수)")
     @PostMapping("/v1/users/find-pw")
     public ResponseEntity<Object> sendPwEmail(
             @RequestBody @Valid ReqAuthEmail req
@@ -135,10 +135,10 @@ public class UserController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("FCM 토큰 등록")
+    @Operation(summary = "FCM 토큰 등록")
     @PostMapping("/v1/users/me/fcm")
     public ResponseEntity<Object> updateFcmToken(
-            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @Parameter(hidden = true) @SessionUser Long userSeq,
             @RequestBody @Valid ReqFcmToken reqFcmToken
     ) {
 
@@ -149,10 +149,10 @@ public class UserController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation("내 포인트 조회")
+    @Operation(summary = "내 포인트 조회")
     @GetMapping("/v1/users/me/point")
     public ResUserPoint getUserPoint(
-            @ApiParam(hidden = true) @SessionUser Long userSeq
+            @Parameter(hidden = true) @SessionUser Long userSeq
     ) {
 
         User user = userService.getUserBySeq(userSeq);

--- a/src/main/java/com/mozi/moziserver/controller/UserController.java
+++ b/src/main/java/com/mozi/moziserver/controller/UserController.java
@@ -25,10 +25,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 
 import static org.springframework.security.web.context.HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY;
 

--- a/src/main/java/com/mozi/moziserver/controller/UserIslandController.java
+++ b/src/main/java/com/mozi/moziserver/controller/UserIslandController.java
@@ -9,8 +9,8 @@ import com.mozi.moziserver.security.SessionUser;
 import com.mozi.moziserver.service.IslandService;
 import com.mozi.moziserver.service.UserRewardService;
 import com.mozi.moziserver.service.UserService;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -35,10 +35,10 @@ public class UserIslandController {
     private final UserService userService;
 
     // TODO ERASE (NOT USED V2)
-    @ApiOperation("섬리스트 조회")
+    @Operation(summary = "섬리스트 조회")
     @GetMapping("/v1/users/me/user-islands")
     public List<ResUserIslandList> getUserIslandListV1(
-            @ApiParam(hidden = true) @SessionUser Long userSeq
+            @Parameter(hidden = true) @SessionUser Long userSeq
     ) {
 
         User user = userService.getUserBySeq(userSeq);
@@ -57,10 +57,10 @@ public class UserIslandController {
         return resUserIslandLists;
     }
 
-    @ApiOperation("섬 오픈하기")
+    @Operation(summary = "섬 오픈하기")
     @PostMapping("/v1/users/me/user-islands/open")
     public ResponseEntity<Object> openUserIslandV1(
-            @ApiParam(hidden = true) @SessionUser Long userSeq
+            @Parameter(hidden = true) @SessionUser Long userSeq
     ) {
 
         User user = userService.getUserBySeq(userSeq);
@@ -70,10 +70,10 @@ public class UserIslandController {
     }
 
     // -------------------- v2 -------------------- //
-    @ApiOperation("섬 리스트 조회")
+    @Operation(summary = "섬 리스트 조회")
     @GetMapping("/v2/users/me/user-islands")
     public List<ResUserIslandList> getUserIslandList(
-            @ApiParam(hidden = true) @SessionUser Long userSeq
+            @Parameter(hidden = true) @SessionUser Long userSeq
     ) {
 
         User user = userService.getUserBySeq(userSeq);

--- a/src/main/java/com/mozi/moziserver/httpException/ResponseError.java
+++ b/src/main/java/com/mozi/moziserver/httpException/ResponseError.java
@@ -132,8 +132,8 @@ public interface ResponseError {
         CHALLENGE_TAG_NOT_EXISTS("challenge tag not exists"),
         DETAIL_ISLAND_NOT_EXISTS("detail island not exists"),
         NOT_EXISTS("not exists"),
-
-        ANIMAL_ITEM_NOT_EXISTS("animal item not exists");
+        ANIMAL_ITEM_NOT_EXISTS("animal item not exists"),
+        RESOURCE_NOT_FOUND("The requested resource could not be found");
 
         private final String message;
 

--- a/src/main/java/com/mozi/moziserver/httpException/ResponseExceptionHandler.java
+++ b/src/main/java/com/mozi/moziserver/httpException/ResponseExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @ControllerAdvice
@@ -53,6 +54,13 @@ public class ResponseExceptionHandler {
         log.error("UNEXPECTED_ERROR", t);
 
         ResponseException ex = ResponseError.InternalServerError.UNEXPECTED_ERROR.getResponseException(t.getMessage());
+        return handle(ex);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    @ResponseBody
+    public ResponseEntity<ResponseException> handleNoResourceFoundException(NoResourceFoundException exception) {
+        ResponseException ex = ResponseError.NotFound.RESOURCE_NOT_FOUND.getResponseException();
         return handle(ex);
     }
 }

--- a/src/main/java/com/mozi/moziserver/log/ApiLogFilter.java
+++ b/src/main/java/com/mozi/moziserver/log/ApiLogFilter.java
@@ -21,10 +21,10 @@ import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;

--- a/src/main/java/com/mozi/moziserver/log/ApiLogFilter.java
+++ b/src/main/java/com/mozi/moziserver/log/ApiLogFilter.java
@@ -1,7 +1,5 @@
 package com.mozi.moziserver.log;
 
-import co.elastic.apm.api.ElasticApm;
-import co.elastic.apm.api.Transaction;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mozi.moziserver.common.Constant;
 import com.mozi.moziserver.security.ResUserSignIn;
@@ -69,12 +67,6 @@ public class ApiLogFilter extends OncePerRequestFilter {
         final String threadId = UUID.randomUUID().toString();
         MDC.put(Constant.MDC_KEY_THREAD_ID, threadId);
         apiLogBuilder.threadId(threadId);
-
-        Transaction transaction = ElasticApm.currentTransaction();
-        final String traceId = transaction.getTraceId();
-        if (StringUtils.hasLength(traceId)) {
-            MDC.put(Constant.MDC_KEY_THREAD_ID, traceId);
-        }
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth != null && auth.isAuthenticated() && SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof ResUserSignIn) {

--- a/src/main/java/com/mozi/moziserver/log/ApiLogFilter.java
+++ b/src/main/java/com/mozi/moziserver/log/ApiLogFilter.java
@@ -77,7 +77,7 @@ public class ApiLogFilter extends OncePerRequestFilter {
         }
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth != null && auth.isAuthenticated()) {
+        if (auth != null && auth.isAuthenticated() && SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof ResUserSignIn) {
             MDC.put(Constant.MDC_KEY_USER_SEQ, ((ResUserSignIn) auth.getPrincipal()).getUserSeq().toString());
         }
 

--- a/src/main/java/com/mozi/moziserver/model/UserChallengeResult.java
+++ b/src/main/java/com/mozi/moziserver/model/UserChallengeResult.java
@@ -3,8 +3,8 @@ package com.mozi.moziserver.model;
 import com.mozi.moziserver.model.mappedenum.UserChallengeResultType;
 import lombok.*;
 
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/adminReq/AdminReqChallengeCreate.java
+++ b/src/main/java/com/mozi/moziserver/model/adminReq/AdminReqChallengeCreate.java
@@ -4,8 +4,8 @@ import com.mozi.moziserver.model.mappedenum.ChallengeTagType;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/adminReq/AdminReqCurrentTagList.java
+++ b/src/main/java/com/mozi/moziserver/model/adminReq/AdminReqCurrentTagList.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.adminReq;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/adminReq/AdminReqCurrentThemeList.java
+++ b/src/main/java/com/mozi/moziserver/model/adminReq/AdminReqCurrentThemeList.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.adminReq;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/adminReq/ReqAdminPostboxMessageAdminCreate.java
+++ b/src/main/java/com/mozi/moziserver/model/adminReq/ReqAdminPostboxMessageAdminCreate.java
@@ -3,8 +3,8 @@ package com.mozi.moziserver.model.adminReq;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/adminReq/ReqAdminSignIn.java
+++ b/src/main/java/com/mozi/moziserver/model/adminReq/ReqAdminSignIn.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import static com.mozi.moziserver.common.Constant.PW_FIELD_NAME;
 

--- a/src/main/java/com/mozi/moziserver/model/entity/AbstractTimeEntity.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/AbstractTimeEntity.java
@@ -5,9 +5,9 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.Column;
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/Animal.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/Animal.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/AnimalItem.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/AnimalItem.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/AnimalMention.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/AnimalMention.java
@@ -1,0 +1,26 @@
+package com.mozi.moziserver.model.entity;
+
+import lombok.Getter;
+
+import jakarta.persistence.*;
+
+@Getter
+@Entity(name = "animal_mention")
+public class AnimalMention extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    private Integer itemTurn;
+
+    private Integer startPoint;
+
+    private Integer rangePoint;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "animal_seq")
+    private Animal animal;
+}

--- a/src/main/java/com/mozi/moziserver/model/entity/BadWord.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/BadWord.java
@@ -2,10 +2,10 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/Board.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/Board.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/Challenge.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/Challenge.java
@@ -6,7 +6,7 @@ import com.mozi.moziserver.model.mappedenum.ChallengeTagType;
 import com.mozi.moziserver.model.mappedenum.ExplanationConverter;
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/ChallengeRecord.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ChallengeRecord.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.entity;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/ChallengeScrap.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ChallengeScrap.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/ChallengeStatistics.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ChallengeStatistics.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/ChallengeStatisticsUserUniqCheck.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ChallengeStatisticsUserUniqCheck.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/ChallengeTag.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ChallengeTag.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/ChallengeTheme.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ChallengeTheme.java
@@ -2,10 +2,10 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/Confirm.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/Confirm.java
@@ -4,7 +4,7 @@ import com.mozi.moziserver.model.mappedenum.ConfirmStateType;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/ConfirmBlockHistory.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ConfirmBlockHistory.java
@@ -2,10 +2,10 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Getter
 @Builder

--- a/src/main/java/com/mozi/moziserver/model/entity/ConfirmLike.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ConfirmLike.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/ConfirmReport.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ConfirmReport.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.entity;
 import com.mozi.moziserver.model.mappedenum.ConfirmReportType;
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/ConfirmSticker.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/ConfirmSticker.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.math.BigDecimal;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/CurrentTagList.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/CurrentTagList.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/CurrentThemeList.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/CurrentThemeList.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/DetailIsland.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/DetailIsland.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.io.Serializable;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/EmailAuth.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/EmailAuth.java
@@ -5,7 +5,7 @@ import com.mozi.moziserver.model.mappedenum.EmailAuthType;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/EmailCheckAuth.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/EmailCheckAuth.java
@@ -4,7 +4,7 @@ import com.mozi.moziserver.model.mappedenum.EmailAuthType;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/Island.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/Island.java
@@ -2,10 +2,10 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/PostboxMessageAdmin.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/PostboxMessageAdmin.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/PostboxMessageAnimal.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/PostboxMessageAnimal.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/PostboxMessageAnimalItem.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/PostboxMessageAnimalItem.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/Question.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/Question.java
@@ -5,7 +5,7 @@ import com.mozi.moziserver.model.mappedenum.QuestionCategoryType;
 import com.mozi.moziserver.model.mappedenum.QuestionStateType;
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/RememberMeToken.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/RememberMeToken.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/Sticker.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/Sticker.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/Suggestion.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/Suggestion.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/Tag.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/Tag.java
@@ -2,10 +2,10 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/User.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/User.java
@@ -4,7 +4,7 @@ import com.mozi.moziserver.common.UserState;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/UserAuth.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserAuth.java
@@ -6,7 +6,7 @@ import com.mozi.moziserver.model.mappedenum.UserRoleTypeConverter;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/entity/UserBoardChecked.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserBoardChecked.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/UserChallenge.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserChallenge.java
@@ -7,7 +7,7 @@ import com.mozi.moziserver.model.mappedenum.UserChallengeStateType;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/mozi/moziserver/model/entity/UserChallengeRecord.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserChallengeRecord.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.entity;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/UserFcm.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserFcm.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * uniq(deviceId, token)

--- a/src/main/java/com/mozi/moziserver/model/entity/UserIsland.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserIsland.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/UserNotice.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserNotice.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.entity;
 import com.mozi.moziserver.model.mappedenum.UserNoticeType;
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/UserPointRecord.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserPointRecord.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.entity;
 import com.mozi.moziserver.model.mappedenum.PointReasonType;
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/UserReward.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserReward.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/UserSticker.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserSticker.java
@@ -2,8 +2,8 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/entity/UserStickerId.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserStickerId.java
@@ -2,10 +2,10 @@ package com.mozi.moziserver.model.entity;
 
 import lombok.*;
 
-import javax.persistence.Embeddable;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/mappedenum/EmailAuthTypeConverter.java
+++ b/src/main/java/com/mozi/moziserver/model/mappedenum/EmailAuthTypeConverter.java
@@ -1,7 +1,7 @@
 package com.mozi.moziserver.model.mappedenum;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class EmailAuthTypeConverter implements AttributeConverter<EmailAuthType, Integer> {

--- a/src/main/java/com/mozi/moziserver/model/mappedenum/ExplanationConverter.java
+++ b/src/main/java/com/mozi/moziserver/model/mappedenum/ExplanationConverter.java
@@ -7,8 +7,8 @@ import com.mozi.moziserver.model.ChallengeExplanation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 /**
  * Mysql post links 타입 JSON

--- a/src/main/java/com/mozi/moziserver/model/mappedenum/QuestionCategoryTypeConverter.java
+++ b/src/main/java/com/mozi/moziserver/model/mappedenum/QuestionCategoryTypeConverter.java
@@ -1,7 +1,7 @@
 package com.mozi.moziserver.model.mappedenum;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class QuestionCategoryTypeConverter implements AttributeConverter<QuestionCategoryType, Integer> {

--- a/src/main/java/com/mozi/moziserver/model/mappedenum/ResultListConverter.java
+++ b/src/main/java/com/mozi/moziserver/model/mappedenum/ResultListConverter.java
@@ -7,8 +7,8 @@ import com.mozi.moziserver.model.UserChallengeResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.util.List;
 
 /**

--- a/src/main/java/com/mozi/moziserver/model/mappedenum/UserAuthTypeConverter.java
+++ b/src/main/java/com/mozi/moziserver/model/mappedenum/UserAuthTypeConverter.java
@@ -1,7 +1,7 @@
 package com.mozi.moziserver.model.mappedenum;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class UserAuthTypeConverter implements AttributeConverter<UserAuthType, Integer> {

--- a/src/main/java/com/mozi/moziserver/model/mappedenum/UserNoticeTypeConverter.java
+++ b/src/main/java/com/mozi/moziserver/model/mappedenum/UserNoticeTypeConverter.java
@@ -1,7 +1,7 @@
 package com.mozi.moziserver.model.mappedenum;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class UserNoticeTypeConverter implements AttributeConverter<UserNoticeType, Integer> {

--- a/src/main/java/com/mozi/moziserver/model/mappedenum/UserRoleTypeConverter.java
+++ b/src/main/java/com/mozi/moziserver/model/mappedenum/UserRoleTypeConverter.java
@@ -2,12 +2,12 @@ package com.mozi.moziserver.model.mappedenum;
 
 import org.springframework.util.StringUtils;
 
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class UserRoleTypeConverter implements AttributeConverter<List<UserRoleType>, String> {

--- a/src/main/java/com/mozi/moziserver/model/req/ReqAuthEmail.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqAuthEmail.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.req;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqChallengeAndDate.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqChallengeAndDate.java
@@ -3,8 +3,8 @@ package com.mozi.moziserver.model.req;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqChallengeList.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqChallengeList.java
@@ -5,8 +5,8 @@ import com.mozi.moziserver.model.mappedenum.ChallengeThemeType;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/com/mozi/moziserver/model/req/ReqConfirm.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqConfirm.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.Date;
 

--- a/src/main/java/com/mozi/moziserver/model/req/ReqConfirmCreate.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqConfirmCreate.java
@@ -2,8 +2,8 @@ package com.mozi.moziserver.model.req;
 
 import lombok.Getter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqConfirmOfUser.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqConfirmOfUser.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.req;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqConfirmSticker.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqConfirmSticker.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.req;
 
 import lombok.Getter;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 

--- a/src/main/java/com/mozi/moziserver/model/req/ReqDeclarationCreate.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqDeclarationCreate.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.req;
 import com.mozi.moziserver.model.mappedenum.ConfirmReportType;
 import lombok.Getter;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqFcmToken.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqFcmToken.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.req;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqList.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqList.java
@@ -3,8 +3,8 @@ package com.mozi.moziserver.model.req;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqQuestionCreate.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqQuestionCreate.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqResign.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqResign.java
@@ -4,7 +4,7 @@ import com.mozi.moziserver.model.mappedenum.ResignReasonType;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/mozi/moziserver/model/req/ReqSuggestionCreate.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqSuggestionCreate.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.req;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqTestUserChallengeStartDateUpdate.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqTestUserChallengeStartDateUpdate.java
@@ -2,7 +2,7 @@ package com.mozi.moziserver.model.req;
 
 import lombok.Getter;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqUserChallengeCreate.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqUserChallengeCreate.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/com/mozi/moziserver/model/req/ReqUserChallengeList.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqUserChallengeList.java
@@ -3,7 +3,7 @@ package com.mozi.moziserver.model.req;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 @Getter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqUserChallengeResult.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqUserChallengeResult.java
@@ -4,7 +4,7 @@ import com.mozi.moziserver.model.mappedenum.UserChallengeResultType;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 @Getter
 @Setter

--- a/src/main/java/com/mozi/moziserver/model/req/ReqUserNickNameAndPw.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqUserNickNameAndPw.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import static com.mozi.moziserver.common.Constant.PW_FIELD_NAME;
 

--- a/src/main/java/com/mozi/moziserver/model/req/ReqUserPw.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqUserPw.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import static com.mozi.moziserver.common.Constant.CURRENT_PW_FIELD_NAME;
 import static com.mozi.moziserver.common.Constant.PW_FIELD_NAME;

--- a/src/main/java/com/mozi/moziserver/model/req/ReqUserSeqAndEmail.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqUserSeqAndEmail.java
@@ -2,8 +2,8 @@ package com.mozi.moziserver.model.req;
 
 import lombok.Getter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 public class ReqUserSeqAndEmail {

--- a/src/main/java/com/mozi/moziserver/model/req/ReqUserSignIn.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqUserSignIn.java
@@ -5,8 +5,8 @@ import com.mozi.moziserver.model.mappedenum.UserAuthType;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import static com.mozi.moziserver.common.Constant.PW_FIELD_NAME;
 

--- a/src/main/java/com/mozi/moziserver/model/req/ReqUserSignUp.java
+++ b/src/main/java/com/mozi/moziserver/model/req/ReqUserSignUp.java
@@ -5,8 +5,8 @@ import com.mozi.moziserver.model.mappedenum.UserAuthType;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import static com.mozi.moziserver.common.Constant.PW_FIELD_NAME;
 

--- a/src/main/java/com/mozi/moziserver/model/res/ResConfirmStickerList.java
+++ b/src/main/java/com/mozi/moziserver/model/res/ResConfirmStickerList.java
@@ -4,7 +4,7 @@ import com.mozi.moziserver.model.entity.ConfirmSticker;
 import com.mozi.moziserver.model.entity.Sticker;
 import lombok.Getter;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.util.List;
 

--- a/src/main/java/com/mozi/moziserver/repository/ConfirmRepositoryImpl.java
+++ b/src/main/java/com/mozi/moziserver/repository/ConfirmRepositoryImpl.java
@@ -6,8 +6,8 @@ import com.querydsl.core.types.Predicate;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/mozi/moziserver/repository/DetailIslandRepositoryImpl.java
+++ b/src/main/java/com/mozi/moziserver/repository/DetailIslandRepositoryImpl.java
@@ -4,8 +4,8 @@
 //import com.mozi.moziserver.model.entity.QDetailIsland;
 //import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 //
-//import javax.persistence.EntityManager;
-//import javax.persistence.PersistenceContext;
+//import jakarta.persistence.EntityManager;
+//import jakarta.persistence.PersistenceContext;
 //
 //public class DetailIslandRepositoryImpl extends QuerydslRepositorySupport implements DetailIslandRepositorySupport {
 //

--- a/src/main/java/com/mozi/moziserver/repository/EmailAuthRepository.java
+++ b/src/main/java/com/mozi/moziserver/repository/EmailAuthRepository.java
@@ -1,7 +1,6 @@
 package com.mozi.moziserver.repository;
 
 import com.mozi.moziserver.model.entity.EmailAuth;
-import com.mozi.moziserver.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +12,6 @@ import java.util.Optional;
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, String> {
     Optional<EmailAuth> findByToken(String token);
 
-    @Query(value = "SELECT * FROM email_auth WHERE user_seq = :user And type = :type ORDER BY created_at desc limit 1", nativeQuery = true)
-    Optional<EmailAuth> findByUserAndTypeOrderByCreatedAt(@Param("user") User user, @Param("type") int type);
+    @Query(value = "SELECT * FROM email_auth WHERE user_seq = :userSeq And type = :type ORDER BY created_at desc limit 1", nativeQuery = true)
+    Optional<EmailAuth> findByUserAndTypeOrderByCreatedAt(@Param("userSeq") Long userSeq, @Param("type") int type);
 }

--- a/src/main/java/com/mozi/moziserver/repository/UserAuthRepositoryImpl.java
+++ b/src/main/java/com/mozi/moziserver/repository/UserAuthRepositoryImpl.java
@@ -7,7 +7,7 @@ import com.querydsl.core.types.Predicate;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.util.StringUtils;
 
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.function.Function;
 

--- a/src/main/java/com/mozi/moziserver/security/DefaultAccessDeniedHandler.java
+++ b/src/main/java/com/mozi/moziserver/security/DefaultAccessDeniedHandler.java
@@ -6,9 +6,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Slf4j

--- a/src/main/java/com/mozi/moziserver/security/DefaultAuthenticationEntryPoint.java
+++ b/src/main/java/com/mozi/moziserver/security/DefaultAuthenticationEntryPoint.java
@@ -5,9 +5,9 @@ import com.mozi.moziserver.httpException.ResponseException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class DefaultAuthenticationEntryPoint implements AuthenticationEntryPoint {

--- a/src/main/java/com/mozi/moziserver/security/RememberMeService.java
+++ b/src/main/java/com/mozi/moziserver/security/RememberMeService.java
@@ -25,8 +25,8 @@ import org.springframework.security.web.authentication.rememberme.AbstractRememb
 import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationException;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.security.Provider;
 import java.security.Security;
 import java.util.Arrays;

--- a/src/main/java/com/mozi/moziserver/security/SessionUserArgResolver.java
+++ b/src/main/java/com/mozi/moziserver/security/SessionUserArgResolver.java
@@ -12,6 +12,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import static com.mozi.moziserver.common.Constant.MDC_KEY_USER_SEQ;
+import static com.mozi.moziserver.common.Constant.TEST_USER_SEQ;
 
 @RequiredArgsConstructor
 public class SessionUserArgResolver implements HandlerMethodArgumentResolver {
@@ -37,6 +38,8 @@ public class SessionUserArgResolver implements HandlerMethodArgumentResolver {
                 MDC.put(MDC_KEY_USER_SEQ, userSeq.toString());
             }
             return userSeq;
+        }else if(SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof org.springframework.security.core.userdetails.User){
+                return TEST_USER_SEQ;
         }
         return null;
     }

--- a/src/main/java/com/mozi/moziserver/service/BadWordService.java
+++ b/src/main/java/com/mozi/moziserver/service/BadWordService.java
@@ -9,7 +9,7 @@ import org.ahocorasick.trie.Emit;
 import org.ahocorasick.trie.Trie;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;

--- a/src/main/java/com/mozi/moziserver/service/EmailAuthService.java
+++ b/src/main/java/com/mozi/moziserver/service/EmailAuthService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMessage;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -375,7 +375,7 @@ public class EmailAuthService {
 
     public void checkEmailAuth(User user) {
 
-        EmailAuth emailAuth = emailAuthRepository.findByUserAndTypeOrderByCreatedAt(user, EmailAuthType.JOIN.getType())
+        EmailAuth emailAuth = emailAuthRepository.findByUserAndTypeOrderByCreatedAt(user.getSeq(), EmailAuthType.JOIN.getType())
                 .orElseThrow(ResponseError.NotFound.EMAIL_AUTH_NOT_EXISTS::getResponseException);
 
         if (emailAuth.getEmailAuthResultState() == null) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: zerori
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
   datasource:
     driverClassName: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DB_ADDRESS}:3306/zeroplanet?autoReconnect=true

--- a/src/test/java/com/mozi/moziserver/SecurityBasedTest.java
+++ b/src/test/java/com/mozi/moziserver/SecurityBasedTest.java
@@ -1,0 +1,61 @@
+package com.mozi.moziserver;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+public class SecurityBasedTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    void 인증된_사용자가_아니면_UNAUTHORIZED_STATUS() throws Exception{
+        mvc
+            .perform(get("/api/v1/users/me"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "test@naver.com",roles = "USER")
+    void 인증된_사용자이면_OK_STATUS() throws Exception{
+        mvc
+            .perform(get("/api/v1/boards"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "test@naver.com", roles = "ADMIN")
+    void admin_ROLE로_user_API_요청하면_FORBIDDEN_STATUS() throws Exception{
+        mvc
+            .perform(get("/api/v1/boards"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "test@naver.com", roles = "ADMIN")
+    void admin_ROLE로_admin_API_요청하면_OK_STATUS() throws Exception{
+        mvc
+            .perform(get("/api/admin/boards"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "test@naver.com", roles = "USER")
+    void user_ROLE로_admin_API_요청하면_FORBIDDEN_STATUS() throws Exception{
+        mvc
+            .perform(get("/api/admin/boards"))
+            .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## 개요 
- #154 SpringBoot 3 마이그레이션 
- Spring Boot 2.7에서 3.x로 업그레이드하여 기술 스택 최신화 및 보안 개선

### 세부 작업 내용
- Spring Boot 2.7 업그레이드: 기존 버전에서 2.7 최신 버전으로 우선 업데이트
- 종속 라이브러리 업데이트: Spring Boot 2.7 호환 라이브러리로 업데이트
- Spring Boot 3 마이그레이션: 2.7에서 3.x 버전으로 최종 업그레이드
- Jakarta EE 네임스페이스 변경: javax 패키지를 jakarta 패키지로 전면 변경
- 라이브러리 호환성 점검: Spring Boot 3 호환 라이브러리로 업데이트 및 버전 조정
- Deprecated API 수정: 사용 중단된 API 식별 및 최신 API로 교체
- 테스트 코드 수정: 변경된 API에 맞춰 테스트 코드 업데이트 및 검증
- 배포 환경 설정 업데이트:
      - GitHub Actions 배포 스크립트의 Java 버전 수정
      - Dockerfile의 JDK 버전 업데이트
- 개발 환경 배포 및 이슈 해결: dev 환경 배포 후 발생한 에러 트러블슈팅


### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#154 -> main

### 테스트 결과 (optional)
- Spring Boot 2.7 업그레이드 후 로컬 테스트 완료
- Spring Boot 3 마이그레이션 후 로컬 테스트 완료
- 개발 서버 배포 후 기능 정상 동작 확인
- 데브 앱에서 모니터링 진행 중


### 특이 사항 (optional)
- Jakarta EE 네임스페이스 변경으로 인한 대규모 import 문 수정
- Spring Boot 3.2.0 업그레이드 후 404 에러가 500 에러로 변경
    : Spring Framework 6.1부터 핸들러가 없을 때 NoResourceFoundException이 발생하며, GlobalExceptionHandler에서 이를 500 상태코드로 처리
    기존 동작 변경: 3.1.6에서는 정상적으로 404 응답을 반환했으나, 3.2.0부터는 NoResourceFoundException이 전역 예외 핸들러에 의해 500 에러로 변환됨
    공식 해결 방안: Spring Framework 6.x 업그레이드 가이드에 따라 NoResourceFoundException에 대한 별도 예외 처리 로직 구현 필요
- RememberMeAuthenticationFilter 내 AuthenticationManager 이슈
    HttpSecurity 설정에서 authenticationManager() 메서드를 통해 커스텀 AuthenticationManager를 직접 주입하도록 수정